### PR TITLE
Add Forked RadioLib to Submodules 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 
 [submodule "Libraries/RadioLib"]
 	path = Libraries/RadioLib
-	url = https://github.com/jgromes/RadioLib.git
+	url = https://github.com/Project-Owl/RadioLib.git
 [submodule "Libraries/arduino-timer"]
 	path = Libraries/arduino-timer
 	url = https://github.com/contrem/arduino-timer


### PR DESCRIPTION
@amirna2 build this new code for the CDP and we found a small compatibility issue with the SX127x Lora Module. Project OWL forked RadioLib and @amirna2 made a small patch to fix the compatibility issues. We will use the forked Library as the new Submodule for the CDP until the patch is fixed in the RadioLib upstream.