### PR TITLE
fix setupInternet conditional

### DIFF
--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -17,7 +17,6 @@ int PapaDuck::setupWithDefaults(std::vector<byte> deviceId, String ssid,
     return err;
   }
 
-  //if (ssid.length() != 0 && password.length() != 0) {
     err = setupWifi("PapaDuck Setup");
     if (err != DUCK_ERR_NONE) {
       logerr("ERROR setupWithDefaults  rc = " + String(err));
@@ -30,11 +29,13 @@ int PapaDuck::setupWithDefaults(std::vector<byte> deviceId, String ssid,
       return err;
     }
 
+  if (ssid.length() != 0 && password.length() != 0) {
     err = setupInternet(ssid, password);
     if (err != DUCK_ERR_NONE) {
       logerr("ERROR setupWithDefaults  rc = " + String(err));
       return err;
     }
+  }
 
     err = setupWebServer(false);
     if (err != DUCK_ERR_NONE) {
@@ -47,7 +48,6 @@ int PapaDuck::setupWithDefaults(std::vector<byte> deviceId, String ssid,
       logerr("ERROR setupWithDefaults  rc = " + String(err));
       return err;
     }
-  //}
   loginfo("setupWithDefaults done");
   return DUCK_ERR_NONE;
 }


### PR DESCRIPTION
Had issue when using dynamic SSID and Password credentials it would prevent the webserver from being created. Conditional was moved to only encapsulate the setupInternet. This allows the webserver to still be created so that the SSID and Password can be entered in later.