### PR TITLE
Add TopicString to Json fields

### DIFF
--- a/examples/6.PaPi-DMS-Lite-Examples/PapiDuckExample-wifi/PapiDuckExample-wifi.ino
+++ b/examples/6.PaPi-DMS-Lite-Examples/PapiDuckExample-wifi/PapiDuckExample-wifi.ino
@@ -183,7 +183,7 @@ void quackJson(std::vector<byte> packetBuffer) {
   Serial.println("[PAPI] Packet Received:");
   Serial.println("[PAPI] sduid:   " + String(sduid.c_str()));
   Serial.println("[PAPI] dduid:   " + String(dduid.c_str()));
-
+  Serial.println("[PAPI] topic:   " + String(toTopicString(packet.topic).c_str()));
   Serial.println("[PAPI] muid:    " + String(muid.c_str()));
   Serial.println("[PAPI] path:    " + String(path.c_str()));
   Serial.println("[PAPI] data:    " + String(payload.c_str()));
@@ -196,10 +196,10 @@ void quackJson(std::vector<byte> packetBuffer) {
   doc["path"].set(path);
   doc["hops"].set(packet.hopCount);
   doc["duckType"].set(packet.duckType);
+  doc["topic"].set(toTopicString(packet.topic));
 
-  std::string cdpTopic = toTopicString(packet.topic);
-
-  std::string topic = "iot-2/evt/" + cdpTopic + "/fmt/json";
+  //std::string cdpTopic = toTopicString(packet.topic);
+  //std::string topic = "iot-2/evt/" + cdpTopic + "/fmt/json";
 
   String jsonstat;
   serializeJson(doc, jsonstat);

--- a/examples/6.PaPi-DMS-Lite-Examples/Serial-PaPiDuckExample/Serial-PaPiDuckExample.ino
+++ b/examples/6.PaPi-DMS-Lite-Examples/Serial-PaPiDuckExample/Serial-PaPiDuckExample.ino
@@ -106,6 +106,7 @@ void quackJson(std::vector<byte> packetBuffer) {
   doc["path"].set(path);
   doc["hops"].set(packet.hopCount);
   doc["duckType"].set(packet.duckType);
+  doc["topic"].set(toTopicString(packet.topic));
 
   String jsonstat;
   serializeJson(doc, Serial);


### PR DESCRIPTION
---
name: Feature change
about: Provide code that changes functionality
title: 'add topic-string to json-fields'
labels: 
assignees: 

---

**Describe at a high level the solution you're providing**
Adds the TopicString to the json which is transmitted to the dms-lite

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
It supplements changes made to the dms-lite repository.
See: https://github.com/Project-Owl/dms-lite/pull/23

**Additional context**
To keep it simple, the same TopicStrings as for the Cloud-DMS are used.
