### PR TITLE
PapaDuck Disconnect Telemetry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,9 +59,14 @@ script:
   - buildExampleSketch 6.PaPi-DMS-Lite-Examples Serial-PaPiDuckExample
   
   - if [[ "$BOARD" != "esp32:esp32:heltec_wifi_lora_32_V2" ]]; then
-      buildExampleSketch 7.TTGO-TBeam-Examples TTGOAPX-Example;
+      buildExampleSketch 7.TTGO-TBeam-Examples TTGO-Telemetry;
     fi
   - if [[ "$BOARD" != "esp32:esp32:heltec_wifi_lora_32_V2" ]]; then
-      buildExampleSketch 7.TTGO-TBeam-Examples TTGOGPSExample;
+      buildExampleSketch 7.TTGO-TBeam-Examples TTGOAPX-Example
     fi
+  - if [[ "$BOARD" != "esp32:esp32:heltec_wifi_lora_32_V2" ]]; then
+      buildExampleSketch 7.TTGO-TBeam-Examples TTGOGPSExample
+    fi
+  
   - buildExampleSketch 8.Encryption DecryptionPapaDuck
+  - buildExampleSketch 9.Telemetry Papa-Downtime-Counter

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-anguage: generic
+language: generic
 env:
   global:
     - CLI_VERSION=master

--- a/examples/7.TTGO-TBeam-Examples/TTGO-Telemetry/TTGO-Telemetry.ino
+++ b/examples/7.TTGO-TBeam-Examples/TTGO-Telemetry/TTGO-Telemetry.ino
@@ -1,0 +1,207 @@
+/**
+ * @file TTGO-Telemetry.ino
+ * @brief Uses the built in Mama Duck and reports additional telemetry data.
+ * 
+ * This example is a Mama Duck, that has GPS capabilities and will send telemetry data with the GPS topic based on the set timer.
+ * @date 2021-04-08
+ * 
+ * @copyright Copyright (c) 2021
+ * ClusterDuck Protocol
+ */
+
+#include <string>
+#include <arduino-timer.h>
+#include <MamaDuck.h>
+#include "FastLED.h"
+
+#ifdef SERIAL_PORT_USBVIRTUAL
+#define Serial SERIAL_PORT_USBVIRTUAL
+#endif
+
+
+//GPS
+#include <TinyGPS++.h>
+#include <axp20x.h>
+
+TinyGPSPlus tgps;
+HardwareSerial GPS(1);
+
+// APX setup (Power)
+#include <Wire.h>
+#include <axp20x.h>
+AXP20X_Class axp;
+
+MamaDuck duck = MamaDuck();
+
+auto timer = timer_create_default();
+const int INTERVAL_MS = 10000;
+char message[32]; 
+int counter = 1;
+
+void setup() {
+  // The Device ID must be unique and 8 bytes long. Typically the ID is stored
+  // in a secure nvram, or provided to the duck during provisioning/registration
+  std::string deviceId("MAMADUCK");
+  std::vector<byte> devId;
+  devId.insert(devId.end(), deviceId.begin(), deviceId.end());
+  // Use the default setup provided by the SDK
+  duck.setupWithDefaults(devId);
+
+  Serial.println("MAMA-DUCK...READY!");
+   Wire.begin(21, 22);
+  if (!axp.begin(Wire, AXP192_SLAVE_ADDRESS)) {
+    Serial.println("AXP192 Begin PASS");
+  } else {
+    Serial.println("AXP192 Begin FAIL");
+  }
+  axp.setPowerOutPut(AXP192_LDO2, AXP202_ON);
+  axp.setPowerOutPut(AXP192_LDO3, AXP202_ON);
+  axp.setPowerOutPut(AXP192_DCDC2, AXP202_ON);
+  axp.setPowerOutPut(AXP192_EXTEN, AXP202_ON);
+  axp.setPowerOutPut(AXP192_DCDC1, AXP202_ON);
+  GPS.begin(9600, SERIAL_8N1, 34, 12);   //17-TX 18-RX
+
+  // initialize the timer. The timer thread runs separately from the main loop
+  // and will trigger sending a counter message.
+  timer.every(INTERVAL_MS, runSensor);
+}
+
+void loop() {
+  timer.tick();
+  // Use the default run(). The Mama duck is designed to also forward data it receives
+  // from other ducks, across the network. It has a basic routing mechanism built-in
+  // to prevent messages from hoping endlessly.
+  duck.run();
+
+}
+
+
+static void smartDelay(unsigned long ms)
+{
+  unsigned long start = millis();
+  do
+  {
+    while (GPS.available())
+      tgps.encode(GPS.read());
+  } while (millis() - start < ms);
+}
+
+bool runSensor(void *) {
+    
+  // Creating a boolean to store the result
+  bool result;
+  
+  // Creating a buffer to save message
+  const byte* buffer;
+
+  // Creating the message to be sent 
+  String message = "Counter:" + String(counter)+ " " +getGPSData() + " " + getBatteryData();
+  Serial.print("[MAMA] sensor data: ");
+  Serial.println(message);
+  
+  // Converting the message from string tp bytes
+  int length = message.length();
+  buffer = (byte*) message.c_str(); 
+  
+  // Sending the data
+  result = sendData(buffer, length);
+  if (result) {
+     Serial.println("[MAMA] runSensor ok.");
+  } else {
+     Serial.println("[MAMA] runSensor failed.");
+  }
+  // Return result
+  return result;
+}
+
+// Getting GPS data
+String getGPSData() {
+
+  // Encoding the GPS
+  smartDelay(5000);
+  
+  // Printing the GPS data
+  Serial.println("--- GPS ---");
+  Serial.print("Latitude  : ");
+  Serial.println(tgps.location.lat(), 5);  
+  Serial.print("Longitude : ");
+  Serial.println(tgps.location.lng(), 4);
+  Serial.print("Altitude  : ");
+  Serial.print(tgps.altitude.feet() / 3.2808);
+  Serial.println("M");
+  Serial.print("Satellites: ");
+  Serial.println(tgps.satellites.value());
+  Serial.print("Time      : ");
+  Serial.print(tgps.time.hour());
+  Serial.print(":");
+  Serial.print(tgps.time.minute());
+  Serial.print(":");
+  Serial.println(tgps.time.second());
+  Serial.print("Speed     : ");
+  Serial.println(tgps.speed.kmph());
+  Serial.println("**********************");
+  
+  // Creating a message of the Latitude and Longitude
+  String sensorVal = "Lat:" + String(tgps.location.lat(), 5) + " Lng:" + String(tgps.location.lng(), 4) + " Alt:" + String(tgps.altitude.feet() / 3.2808);
+
+  // Check to see if GPS data is being received
+  if (millis() > 5000 && tgps.charsProcessed() < 10)
+  {
+    Serial.println(F("No GPS data received: check wiring"));
+  }
+
+  return sensorVal;
+}
+
+bool sendData(const byte* buffer, int length) {
+  bool sentOk = false;
+  
+  // Send Data can either take a byte buffer (unsigned char) or a vector
+  int err = duck.sendData(topics::location, buffer, length);
+  if (err == DUCK_ERR_NONE) {
+     counter++;
+     sentOk = true;
+  }
+  if (!sentOk) {
+    Serial.println("[MAMA] Failed to send data. error = " + String(err));
+  }
+  return sentOk;
+}
+
+// Getting the battery data
+String getBatteryData() {
+  
+  int isCharging = axp.isChargeing();
+  boolean isFullyCharged = axp.isChargingDoneIRQ();
+  float batteryVoltage = axp.getBattVoltage();
+  float batteryDischarge = axp.getAcinCurrent();
+  float getTemp = axp.getTemp();  
+  float battPercentage = axp.getBattPercentage();
+   
+  Serial.println("--- Power ---");
+  Serial.print("Duck charging (1 = Yes): ");
+  Serial.println(isCharging);
+  Serial.print("Fully Charged: ");
+  Serial.println(isFullyCharged);
+  Serial.print("Battery Voltage: ");
+  Serial.println(batteryVoltage);
+  Serial.print("Battery Discharge: ");
+  Serial.println(batteryDischarge);  
+  Serial.print("Board Temperature: ");
+  Serial.println(getTemp);
+  Serial.print("battery Percentage: ");
+  Serial.println(battPercentage);
+   
+
+  String sensorVal = 
+  "Charging:" + 
+  String(isCharging) +  
+  " Full:" +
+  String(isFullyCharged)+
+  " Volts:" +
+  String(batteryVoltage) + 
+  " Temp:" +
+  String(getTemp);
+
+  return sensorVal;
+}

--- a/examples/9.Telemetry/Papa-Downtime-Counter.ino/Papa-Downtime-Counter.ino
+++ b/examples/9.Telemetry/Papa-Downtime-Counter.ino/Papa-Downtime-Counter.ino
@@ -1,0 +1,331 @@
+/**
+ * @file Papa-Downtime-Counter.ino
+ * @author 
+ * @brief Uses pre-built PapaDuck and will send downtime data after reconnecting
+ * 
+ * This example will configure and run a Papa Duck that connects to the cloud
+ * and forwards all messages (except  pings) to the cloud. It will also send
+ * how long it was disconnected from cloud network as well as how many times
+ * it has disconnected. Watch working session
+ * https://www.youtube.com/watch?v=xx4aYct8m7o&t
+ * 
+ * @date 2021-04-08
+ * 
+ */
+
+#include <ArduinoJson.h>
+#include <PubSubClient.h>
+#include <WiFiClientSecure.h>
+#include <arduino-timer.h>
+#include <string>
+
+/* CDP Headers */
+#include <PapaDuck.h>
+#include <CdpPacket.h>
+
+#define MQTT_RETRY_DELAY_MS 500
+#define WIFI_RETRY_DELAY_MS 5000
+
+#define SSID ""
+#define PASSWORD ""
+
+
+
+
+// Used for Mqtt client connection
+// Provided when a Papa Duck device is created in DMS
+#define ORG         ""
+#define DEVICE_ID   ""
+#define DEVICE_TYPE ""
+#define TOKEN       ""
+char server[] = ORG ".messaging.internetofthings.ibmcloud.com";
+char authMethod[] = "use-token-auth";
+char token[] = TOKEN;
+char clientId[] = "d:" ORG ":" DEVICE_TYPE ":" DEVICE_ID;
+
+// Use pre-built papa duck
+PapaDuck duck = PapaDuck();
+
+DuckDisplay* display = NULL;
+
+// Set this to false if testing quickstart on IBM IoT Platform
+bool use_auth_method = true;
+
+auto timer = timer_create_default();
+
+int disconnectTime;
+bool disconnect = false;
+int failCounter = 0;
+
+WiFiClientSecure wifiClient;
+PubSubClient client(server, 8883, wifiClient);
+// / DMS locator URL requires a topicString, so we need to convert the topic
+// from the packet to a string based on the topics code
+std::string toTopicString(byte topic) {
+
+  std::string topicString;
+
+  switch (topic) {
+    case topics::status:
+      topicString = "status";
+      break;
+    case topics::cpm:
+      topicString = "portal";
+      break;
+    case topics::sensor:
+      topicString = "sensor";
+      break;
+    case topics::alert:
+      topicString = "alert";
+      break;
+    case topics::location:
+      topicString = "gps";
+      break;
+    case topics::health:
+      topicString ="health";
+      break;
+    default:
+      topicString = "status";
+  }
+
+  return topicString;
+}
+
+String convertToHex(byte* data, int size) {
+  String buf = "";
+  buf.reserve(size * 2); // 2 digit hex
+  const char* cs = "0123456789ABCDEF";
+  for (int i = 0; i < size; i++) {
+    byte val = data[i];
+    buf += cs[(val >> 4) & 0x0F];
+    buf += cs[val & 0x0F];
+  }
+  return buf;
+}
+
+// WiFi connection retry
+bool retry = true;
+void quackJson(std::vector<byte> packetBuffer) {
+
+  CdpPacket packet = CdpPacket(packetBuffer);
+  const int bufferSize = 4 * JSON_OBJECT_SIZE(4);
+  StaticJsonDocument<bufferSize> doc;
+
+  // Here we treat the internal payload of the CDP packet as a string
+  // but this is mostly application dependent. 
+  // The parsingf here is optional. The Papa duck could simply decide to
+  // forward the CDP packet as a byte array and let the Network Server (or DMS) deal with
+  // the parsing based on some business logic.
+
+  std::string payload(packet.data.begin(), packet.data.end());
+  std::string sduid(packet.sduid.begin(), packet.sduid.end());
+  std::string dduid(packet.dduid.begin(), packet.dduid.end());
+
+  std::string muid(packet.muid.begin(), packet.muid.end());
+  std::string path(packet.path.begin(), packet.path.end());
+
+  Serial.println("[PAPA] Packet Received:");
+  Serial.println("[PAPA] sduid:   " + String(sduid.c_str()));
+  Serial.println("[PAPA] dduid:   " + String(dduid.c_str()));
+
+  Serial.println("[PAPA] muid:    " + String(muid.c_str()));
+  Serial.println("[PAPA] path:    " + String(path.c_str()));
+  Serial.println("[PAPA] data:    " + String(payload.c_str()));
+  Serial.println("[PAPA] hops:    " + String(packet.hopCount));
+  Serial.println("[PAPA] duck:    " + String(packet.duckType));
+
+  doc["DeviceID"] = sduid;
+  doc["MessageID"] = muid;
+  doc["Payload"].set(payload);
+  doc["path"].set(path);
+  doc["hops"].set(packet.hopCount);
+  doc["duckType"].set(packet.duckType);
+
+  std::string cdpTopic = toTopicString(packet.topic);
+
+  display->clear();
+  display->drawString(0, 10, "New Message");
+  display->drawString(0, 20, sduid.c_str());
+  display->drawString(0, 30, muid.c_str());
+  display->drawString(0, 40, cdpTopic.c_str());
+  display->sendBuffer();
+    
+  std::string topic = "iot-2/evt/" + cdpTopic + "/fmt/json";
+
+  String jsonstat;
+  serializeJson(doc, jsonstat);
+
+  if (client.publish(topic.c_str(), jsonstat.c_str())) {
+    Serial.println("[PAPA] Packet forwarded:");
+    serializeJsonPretty(doc, Serial);
+    Serial.println("");
+    Serial.println("[PAPA] Publish ok");
+    display->drawString(0, 60, "Publish ok");
+     display->sendBuffer();
+  } else {
+    Serial.println("[PAPA] Publish failed");
+    display->drawString(0, 60, "Publish failed");
+    display->sendBuffer();
+    failCounter++;
+  }
+}
+
+// The callback method simply takes the incoming packet and
+// converts it to a JSON string, before sending it out over WiFi
+void handleDuckData(std::vector<byte> packetBuffer) {
+  Serial.println("[PAPA] got packet: " +
+                 convertToHex(packetBuffer.data(), packetBuffer.size()));
+  quackJson(packetBuffer);
+}
+
+void setup() {
+  // We are using a hardcoded device id here, but it should be retrieved or
+  // given during the device provisioning then converted to a byte vector to
+  // setup the duck NOTE: The Device ID must be exactly 8 bytes otherwise it
+  // will get rejected
+  std::string deviceId("PAPADUCK");
+  std::vector<byte> devId;
+  devId.insert(devId.end(), deviceId.begin(), deviceId.end());
+
+  // the default setup is equivalent to the above setup sequence
+  duck.setupWithDefaults(devId, SSID, PASSWORD);
+
+  display = DuckDisplay::getInstance();
+  // DuckDisplay instance is returned unconditionally, if there is no physical
+  // display the functions will not do anything
+  display->setupDisplay(duck.getType(), devId);
+
+  // register a callback to handle incoming data from duck in the network
+  duck.onReceiveDuckData(handleDuckData);
+  
+  timer.every(3000000, sendFailReport);
+
+  Serial.println("[PAPA] Setup OK! ");
+  
+  // we are done
+  display->showDefaultScreen();
+}
+
+
+
+void loop() {
+
+  if (!duck.isWifiConnected() && retry) {
+    if(!disconnect) {
+      disconnectTime = millis();
+      disconnect = true;
+    }
+
+    String ssid = duck.getSsid();
+    String password = duck.getPassword();
+
+    Serial.println("[PAPA] WiFi disconnected, reconnecting to local network: " +
+                   ssid);
+
+    int err = duck.reconnectWifi(ssid, password);
+
+    if (err != DUCK_ERR_NONE) {
+      retry = false;
+      timer.in(5000, enableRetry);
+    }
+  }
+  if (duck.isWifiConnected() && retry) {
+    setup_mqtt(use_auth_method);
+  }
+
+  duck.run();
+  timer.tick();
+}
+
+void setup_mqtt(bool use_auth) {
+  bool connected = client.connected();
+  if (connected) {
+    return;
+  }
+
+  if(!disconnect) {
+    disconnectTime = millis();
+    disconnect = true;
+  }
+
+  if (use_auth) {
+    connected = client.connect(clientId, authMethod, token);
+  } else {
+    connected = client.connect(clientId);
+  }
+  if (connected) {
+    Serial.println("[PAPA] Mqtt client is connected!");
+    disconnect = false;
+    int timeDisconnected = millis() - disconnectTime;
+    timeDisconnected = timeDisconnected/1000;
+    quackDownReport("Time Disconnected: " + String(timeDisconnected));
+    return;
+  }
+  retry_mqtt_connection(1000);
+  
+}
+
+void quackDownReport(String payload) {
+  Serial.println("Send QuackDownReport");
+
+  const int bufferSize = 4 * JSON_OBJECT_SIZE(4);
+  StaticJsonDocument<bufferSize> doc;
+
+  doc["DeviceID"] = "PAPADUCK";
+  doc["MessageID"] = createUuid(4);
+  doc["Payload"].set(payload);
+  doc["path"] = "PAPADUCK";
+  doc["hops"] = "0";
+  doc["duckType"] = "1";
+    
+  std::string topic = "iot-2/evt/health/fmt/json";
+
+  String jsonstat;
+  serializeJson(doc, jsonstat);
+
+  if (client.publish(topic.c_str(), jsonstat.c_str())) {
+    Serial.println("[PAPA] Packet forwarded:");
+    serializeJsonPretty(doc, Serial);
+    Serial.println("");
+    Serial.println("[PAPA] Publish ok");
+    display->drawString(0, 60, "Publish ok");
+    display->sendBuffer();
+  } else {
+    Serial.println("[PAPA] Publish failed");
+    display->drawString(0, 60, "Publish failed");
+    display->sendBuffer();
+    failCounter++;
+  }
+
+}
+
+// Creates a unique id for the message
+String createUuid(int length) {
+  String msg = "";
+  int i;
+
+  for (i = 0; i < length; i++) {
+    byte randomValue = random(0, 36);
+    if (randomValue < 26) {
+      msg = msg + char(randomValue + 'a');
+    } else {
+      msg = msg + char((randomValue - 26) + '0');
+    }
+  }
+  return msg;
+}
+
+bool sendFailReport(void*) {
+  quackDownReport(String(failCounter));
+}
+
+bool enableRetry(void*) {
+  retry = true;
+  return retry;
+}
+
+void retry_mqtt_connection(int delay_ms) {
+  Serial.println("[PAPA] Could not connect to MQTT...............................");
+  retry = false;
+  timer.in(delay_ms, enableRetry);
+}


### PR DESCRIPTION
---
name: PapaDuck Disconnect Telemetry
title: 'Papa and Mama Telemetry Examples'
labels: 'Telemetry'
assignees: 'Nick Feuer'

---

**Describe at a high level the solution you're providing**
Added telemetry examples for Papa and TTGO. This will help better understand device performance in the field.

**Is this a patch, a minor version change, or a major version change**
Minor

**Additional context**
Added new telemetry collection files for PapaDuck and TTGO MamaDucks. The PapaDuck-Disconnect-Counter will send connection reports that can be used against packet loss data. TTGO MamaDuck will send reports on battery power, charging status, board temperature, and gps location. This currently only works on TTGO devices.
