### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,13 @@ before_install:
   #- arduino-cli lib install --git-url https://github.com/Call-for-Code/ClusterDuck-Protocol.git
   - arduino-cli lib install --git-url https://github.com/bblanchon/ArduinoJson.git
   - arduino-cli lib install --git-url https://github.com/me-no-dev/AsyncTCP
-  # - arduino-cli lib install --git-url https://github.com/ThingPulse/esp8266-oled-ssd1306
+  #- arduino-cli lib install --git-url https://github.com/ThingPulse/esp8266-oled-ssd1306
   # This is exactly the same library as above
   - arduino-cli lib install "ESP8266 and ESP32 Oled Driver for SSD1306 displays"
   - arduino-cli lib install --git-url https://github.com/me-no-dev/ESPAsyncWebServer
-  - arduino-cli lib install --git-url https://github.com/olikraus/U8g2_Arduino.git
+  #- arduino-cli lib install --git-url https://github.com/olikraus/U8g2_Arduino.git
+  # This is exactly the same library as above
+  - arduino-cli lib install "U8g2"
   - arduino-cli lib install --git-url https://github.com/bakercp/CRC32.git
   - arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_Sensor
   - arduino-cli lib install --git-url https://github.com/knolleary/pubsubclient.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,13 +31,19 @@ before_install:
   #- arduino-cli lib install --git-url https://github.com/knolleary/pubsubclient
   # This is exactly the same library as above, verified with arduino-cli lib search
   - arduino-cli lib install "PubSubClient"
-  - arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_BMP085_Unified
+  #- arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_BMP085_Unified
+  # This is exactly the same library as above, verified with arduino-cli lib search
+  - arduino-cli lib install "Adafruit BMP085 Unified"
   - arduino-cli lib install --git-url https://github.com/luciansabo/GP2YDustSensor.git
-  - arduino-cli lib install --git-url https://github.com/adafruit/DHT-sensor-library
-  - arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_BMP280_Library
-  - arduino-cli lib install --git-url https://github.com/miguel5612/MQSensorsLib.git
+  #- arduino-cli lib install --git-url https://github.com/adafruit/DHT-sensor-library
+  - arduino-cli lib install "DHT sensor library"
+  #- arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_BMP280_Library
+  - arduino-cli lib install "Adafruit BMP280 Library"
+  #- arduino-cli lib install --git-url https://github.com/miguel5612/MQSensorsLib.git
+  - arduino-cli lib install "MQUnifiedsensor"
   - arduino-cli lib install --git-url https://github.com/FastLED/FastLED.git
   - arduino-cli lib install --git-url https://github.com/mikalhart/IridiumSBD.git
+  # The following two are not listed in the Arduino library, so another work-around will have to be found
   - arduino-cli lib install --git-url https://github.com/lewisxhe/AXP202X_Library
   - arduino-cli lib install --git-url https://github.com/mikalhart/TinyGPSPlus.git
   - arduino-cli lib install --git-url https://github.com/Project-Owl/Crypto.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - arduino-cli config set library.enable_unsafe_install true          
   - arduino-cli lib install --git-url https://github.com/contrem/arduino-timer.git
   - arduino-cli lib install --git-url https://github.com/jgromes/RadioLib.git
-  - arduino-cli lib install --git-url https://github.com/Call-for-Code/ClusterDuck-Protocol.git
+  #- arduino-cli lib install --git-url https://github.com/Call-for-Code/ClusterDuck-Protocol.git
   - arduino-cli lib install --git-url https://github.com/bblanchon/ArduinoJson.git
   - arduino-cli lib install --git-url https://github.com/me-no-dev/AsyncTCP
   # - arduino-cli lib install --git-url https://github.com/ThingPulse/esp8266-oled-ssd1306

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,17 @@ before_install:
   - arduino-cli lib install --git-url https://github.com/bblanchon/ArduinoJson.git
   - arduino-cli lib install --git-url https://github.com/me-no-dev/AsyncTCP
   #- arduino-cli lib install --git-url https://github.com/ThingPulse/esp8266-oled-ssd1306
-  # This is exactly the same library as above
+  # This is exactly the same library as above, verified with arduino-cli lib search
   - arduino-cli lib install "ESP8266 and ESP32 Oled Driver for SSD1306 displays"
   - arduino-cli lib install --git-url https://github.com/me-no-dev/ESPAsyncWebServer
   #- arduino-cli lib install --git-url https://github.com/olikraus/U8g2_Arduino.git
-  # This is exactly the same library as above
+  # This is exactly the same library as above, verified with arduino-cli lib search
   - arduino-cli lib install "U8g2"
   - arduino-cli lib install --git-url https://github.com/bakercp/CRC32.git
   - arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_Sensor
-  - arduino-cli lib install --git-url https://github.com/knolleary/pubsubclient
+  #- arduino-cli lib install --git-url https://github.com/knolleary/pubsubclient
+  # This is exactly the same library as above, verified with arduino-cli lib search
+  - arduino-cli lib install "PubSubClient"
   - arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_BMP085_Unified
   - arduino-cli lib install --git-url https://github.com/luciansabo/GP2YDustSensor.git
   - arduino-cli lib install --git-url https://github.com/adafruit/DHT-sensor-library

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,9 @@ before_install:
   - arduino-cli lib install --git-url https://github.com/Call-for-Code/ClusterDuck-Protocol.git
   - arduino-cli lib install --git-url https://github.com/bblanchon/ArduinoJson.git
   - arduino-cli lib install --git-url https://github.com/me-no-dev/AsyncTCP
-  - arduino-cli lib install --git-url https://github.com/ThingPulse/esp8266-oled-ssd1306
+  # - arduino-cli lib install --git-url https://github.com/ThingPulse/esp8266-oled-ssd1306
+  # This is exactly the same library as above
+  - arduino-cli lib install "ESP8266 and ESP32 Oled Driver for SSD1306 displays"
   - arduino-cli lib install --git-url https://github.com/me-no-dev/ESPAsyncWebServer
   - arduino-cli lib install --git-url https://github.com/olikraus/U8g2_Arduino.git
   - arduino-cli lib install --git-url https://github.com/bakercp/CRC32.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
   - arduino-cli lib install "U8g2"
   - arduino-cli lib install --git-url https://github.com/bakercp/CRC32.git
   - arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_Sensor
-  - arduino-cli lib install --git-url https://github.com/knolleary/pubsubclient.git
+  - arduino-cli lib install --git-url https://github.com/knolleary/pubsubclient
   - arduino-cli lib install --git-url https://github.com/adafruit/Adafruit_BMP085_Unified
   - arduino-cli lib install --git-url https://github.com/luciansabo/GP2YDustSensor.git
   - arduino-cli lib install --git-url https://github.com/adafruit/DHT-sensor-library


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
In the .travis.yml file, I made a modification to pull a particular library by NAME instead of the Git URL. There is some change in arduino-cli that expects the name of the header file to match the name of the downloaded library, which is not the case for some of our dependencies.

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
N/A

**Additional context**
The library in question is esp8266-oled-ssd1306
