### PR TITLE
fix CA_CERT ifdef else condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our Code of Conduc
 This project is licensed under the Apache 2 License - see the [LICENSE](LICENSE) file for details.
 
 ## Version
-v2.9.11
+v2.9.12
 
 
 [Project OWL]: <https://www.project-owl.com/>

--- a/examples/1.Ducks/PapaDuck/PapaDuck.ino
+++ b/examples/1.Ducks/PapaDuck/PapaDuck.ino
@@ -27,13 +27,6 @@
 #define MQTT_RETRY_DELAY_MS 500
 #define WIFI_RETRY_DELAY_MS 5000
 
-// This is the DigiCert Global Root CA, which is the root CA cert for
-// https://internetofthings.ibmcloud.com/
-// It expires November 9, 2031.
-// To connect to a different cloud provider or server, you may need to use a
-// different cert. For details, see
-// https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFiClientSecure
-
 //Uncomment CA_CERT if you want to use the certificate auth method
 //#define CA_CERT
 #ifdef CA_CERT
@@ -60,6 +53,12 @@ const char* example_root_ca = \
   "YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\n" \
   "CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\n" \
   "-----END CERTIFICATE-----\n";
+  // This is the DigiCert Global Root CA, which is the root CA cert for
+  // https://internetofthings.ibmcloud.com/
+  // It expires November 9, 2031.
+  // To connect to a different cloud provider or server, you may need to use a
+  // different cert. For details, see
+  // https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFiClientSecure
 #endif
 
 #define SSID ""
@@ -242,11 +241,11 @@ void setup() {
   duck.onReceiveDuckData(handleDuckData);
 
   #ifdef CA_CERT
+  Serial.println("[PAPA] Using root CA cert");
   wifiClient.setCACert(example_root_ca);
-  while (!wifiClient.connect(server, port)) {
-    Serial.println("[PAPA] Failed to connect to " + String(server) + ":" + String(port));
-    delay(5000);
-  }
+  #else
+  Serial.println("[PAPA] Using insecure TLS");
+  wifiClient.setInsecure();
   #endif
 
   Serial.println("[PAPA] Setup OK! ");

--- a/examples/1.Ducks/PapaDuck/PapaDuck.ino
+++ b/examples/1.Ducks/PapaDuck/PapaDuck.ino
@@ -9,7 +9,7 @@
  * try to publish all messages in the queue. You can change the size of the queue
  * by changing `QUEUE_SIZE_MAX`.
  * 
- * @date 2021-06-03
+ * @date 2021-06-17
  * 
  */
 

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
         "email": "info@project-owl.com",
         "url": "https://www.project-owl.com"
     },
-    "version": "2.9.11",
+    "version": "2.9.12",
     "repository":
     {
         "type": "git",

--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -6,7 +6,7 @@
 namespace duckutils {
 
   namespace {
-    std::string cdpVersion = "2.9.11";
+    std::string cdpVersion = "2.9.12";
   }
 
 volatile bool interruptEnabled = true;


### PR DESCRIPTION
Followup from #200

When I try running the version of PapaDuck.ino before this commit, it's not able to connect:

```
11:29:17.650 -> [INF: Duck.cpp]  setupSerial rc = 0
11:29:17.650 -> [INF: Duck.cpp]  setupDeviceId rc = 0
11:29:17.687 -> [INF: Duck.cpp]  setupRadio rc = 0
11:29:17.797 -> [D][WiFiGeneric.cpp:374] _eventCallback(): Event: 0 - WIFI_READY
11:29:17.797 -> [D][WiFiGeneric.cpp:374] _eventCallback(): Event: 14 - AP_START
11:29:17.983 -> [INF: DuckNet.cpp]  Created Wifi Access Point
11:29:18.021 -> [INF: Duck.cpp]  setupWifi OK
11:29:18.021 -> [INF: DuckNet.cpp]  Created local DNS
11:29:18.021 -> [INF: Duck.cpp]  setupDns OK
11:29:18.021 -> [INF: DuckNet.cpp]  Setting up Web Server
11:29:18.021 -> [DBG: DuckNet.cpp]  Web Server using main page
11:29:18.021 -> [INF: Duck.cpp]  setupWebServer OK
11:29:18.021 -> [I][ArduinoOTA.cpp:141] begin(): OTA server at: esp32-24a1606d7b20.local:3232
11:29:18.021 -> setupOTA rc = 0
11:29:18.021 -> [D][WiFiGeneric.cpp:374] _eventCallback(): Event: 2 - STA_START
11:29:23.315 -> [D][WiFiGeneric.cpp:374] _eventCallback(): Event: 1 - SCAN_DONE
11:29:23.315 -> [DBG: DuckNet.cpp]  Networks found: 6
11:29:23.353 -> [DBG: DuckNet.cpp]  Given ssid is available!
11:29:23.353 -> [DBG: DuckNet.cpp]  setupInternet: connecting to WiFi access point SSID: <redacted>
11:29:28.781 -> [D][WiFiGeneric.cpp:374] _eventCallback(): Event: 4 - STA_CONNECTED
11:29:33.250 -> [D][WiFiGeneric.cpp:374] _eventCallback(): Event: 7 - STA_GOT_IP
11:29:33.250 -> [D][WiFiGeneric.cpp:419] _eventCallback(): STA IP: 192.168.1.23, MASK: 255.255.255.0, GW: 192.168.1.1
11:29:33.250 -> [INF: DuckNet.cpp]  Duck connected to internet!
11:29:33.288 -> [INF: Duck.cpp]  setupInternet OK
11:29:33.288 -> [INF: PapaDuck.cpp]  setupWithDefaults done
11:29:35.419 -> [PAPA] Here
11:29:35.419 -> [PAPA] Setup OK! 
11:29:35.607 -> [V][ssl_client.cpp:59] start_ssl_client(): Free internal heap before TLS 223068
11:29:35.607 -> [V][ssl_client.cpp:63] start_ssl_client(): rootCABuff: 0x0, pskIdent: 0x0, psKey: 0x0, insecure: 0
11:29:35.607 -> [E][WiFiClientSecure.cpp:133] connect(): start_ssl_client: -1
11:29:35.607 -> [V][ssl_client.cpp:267] stop_ssl_socket(): Cleaning SSL connection.
11:29:35.607 -> [PAPA] Could not connect to MQTT...............................
11:29:36.617 -> [V][ssl_client.cpp:59] start_ssl_client(): Free internal heap before TLS 223516
11:29:36.617 -> [V][ssl_client.cpp:63] start_ssl_client(): rootCABuff: 0x0, pskIdent: 0x0, psKey: 0x0, insecure: 0
11:29:36.617 -> [E][WiFiClientSecure.cpp:133] connect(): start_ssl_client: -1
11:29:36.654 -> [V][ssl_client.cpp:267] stop_ssl_socket(): Cleaning SSL connection.
11:29:37.632 -> [V][ssl_client.cpp:59] start_ssl_client(): Free internal heap before TLS 223516
11:29:37.632 -> [V][ssl_client.cpp:63] start_ssl_client(): rootCABuff: 0x0, pskIdent: 0x0, psKey: 0x0, insecure: 0
11:29:37.632 -> [E][WiFiClientSecure.cpp:133] connect(): start_ssl_client: -1
```

The output from ssl_client.cpp:63 is mine.

The PubSubClient tries to use the wifiClient to connect to the server. PubSubClient calls [_client->connect](https://github.com/knolleary/pubsubclient/blob/2d228f2f862a95846c65a8518c79f48dfc8f188c/src/PubSubClient.cpp#L192), which gives an error because WiFiClientSecure essentially [requires](https://github.com/espressif/arduino-esp32/blob/371f382db7dd36c470bb2669b222adf0a497600d/libraries/WiFiClientSecure/src/ssl_client.cpp#L61) one of the [three encryption methods](https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFiClientSecure) or else requires [WiFiClient::setInsecure()](https://github.com/espressif/arduino-esp32/blob/371f382db7dd36c470bb2669b222adf0a497600d/libraries/WiFiClientSecure/src/WiFiClientSecure.h#L66) to be called.

With my new commit, I've tested with CA_CERT and without, and it worked for me.

As further work on this PR, I can update the documentation.