### PR TITLE
src: reduce storage space by ~169 KB when no display

### DIFF
--- a/src/DuckDisplay.cpp
+++ b/src/DuckDisplay.cpp
@@ -1,5 +1,14 @@
 #include "DuckDisplay.h"
+
+#ifdef CDPCFG_OLED_CLASS
+// 2021-06-18: Including iostream adds ~169KB to the build.
 #include <iostream>
+
+#include "include/DuckTypes.h"
+#include "include/DuckEsp.h"
+#include "include/DuckUtils.h"
+#endif
+
 #include <vector>
 
 #ifdef CDPCFG_OLED_CLASS
@@ -100,7 +109,7 @@ static const unsigned char u8g_logo_bits[] U8X8_PROGMEM = {
     0x00, 0x00, 0x00, 0x00,
 };
 
-#endif
+#endif // CDPCFG_OLED_CLASS
 
 #define u8g_logo_width 128
 #define u8g_logo_height 64
@@ -115,6 +124,7 @@ DuckDisplay* DuckDisplay::getInstance() {
   }
   return instance;
 }
+
 #ifndef CDPCFG_OLED_NONE
 
 void DuckDisplay::setupDisplay(int duckType, std::vector<byte> name) {
@@ -168,7 +178,8 @@ void DuckDisplay::print(String s) { u8g2.print(s); }
 void DuckDisplay::clear(void) { u8g2.clear(); }
 
 void DuckDisplay::sendBuffer(void){  u8g2.sendBuffer();}
- 
+
+#ifndef CDPCFG_OLED_NONE
 String DuckDisplay::duckTypeToString(int duckType) {
   String duckTypeStr = "";
   switch (duckType) {
@@ -189,7 +200,7 @@ String DuckDisplay::duckTypeToString(int duckType) {
   }
   return duckTypeStr;
 }
-
+#endif // CDPCFG_OLED_NONE
 
 
 
@@ -218,6 +229,6 @@ void DuckDisplay::showDefaultScreen() {
   setCursor(0, 70);
   print("MC: " + duckesp::getDuckMacAddress(false));
   u8g2.sendBuffer(); 
-#endif
+#endif // CDPCFG_OLED_64x32
 }
 #endif // CDPCFG_OLED_NONE

--- a/src/DuckDisplay.h
+++ b/src/DuckDisplay.h
@@ -16,12 +16,9 @@
 #include <Arduino.h>
 #include <vector>
 #include <WString.h>
-#include "include/DuckTypes.h"
-#include "include/DuckEsp.h"
-#include "include/DuckUtils.h"
 #ifndef CDPCFG_OLED_NONE
 #include <U8g2lib.h>
-#endif
+#endif // CDPCFG_OLED_NONE
 /**
  * @brief Internal OLED Display abstraction.
  *
@@ -104,17 +101,20 @@ public:
   
   //TODO implement this for the U8g2 library
   void log(String text) {}
-#endif
+#endif // CDPCFG_OLED_NONE
 private:
   DuckDisplay();
   DuckDisplay(DuckDisplay const&) = delete;
   DuckDisplay& operator=(DuckDisplay const&) = delete;
   static DuckDisplay* instance;
+
+#ifndef CDPCFG_OLED_NONE
   int duckType;
   String duckName;
   String duckTypeToString(int duckType);
   uint8_t width;
   uint8_t height;
+#endif // CDPCFG_OLED_NONE
 };
 
 #endif /* DUCKDISPLAY_H_ */


### PR DESCRIPTION
- Primary improvement: removed include to iostream when no display is available
- Removed member variables from DuckDisplay when no display is available
- Moved ClusterDuck includes to .cpp file
- Improved readability of some `#endif`s

**Describe at a high level the solution you're providing**
For boards without a display:

- ~169 KB storage saved, reduced by ~13%
- ~5.4 KB dynamic memory saved, reduced by ~10%

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
No (but there was helpful, [related conversation](https://clusterduck-protocol.slack.com/archives/CLJ3L5KC4/p1623111379103600) in the Slack about a week ago)

**Additional context**
I was running into memory issues (board was continuously resetting / stack overwriting due to running out of memory) on Heltec Wireless Stick Lite. 

Tested with Heltec Wireless Stick Lite. Example output:

```
Sketch uses 1126566 bytes (85%) of program storage space. Maximum is 1310720 bytes. 
Global variables use 46584 bytes (14%) of dynamic memory, leaving 281096 bytes for local variables. Maximum is 327680 bytes.
```

The `#include <iostream>` is the main culprit. Same everything as above, but with iostream:

```
Sketch uses 1295390 bytes (98%) of program storage space. Maximum is 1310720 bytes.
Global variables use 52024 bytes (15%) of dynamic memory, leaving 275656 bytes for local variables. Maximum is 327680 bytes.
```

Tested with ARDUINO_HELTEC_WIFI_LORA_32_V2 to make sure I didn't break it:

```
Sketch uses 1312106 bytes (39%) of program storage space. Maximum is 3342336 bytes.
Global variables use 53880 bytes (16%) of dynamic memory, leaving 273800 bytes for local variables. Maximum is 327680 bytes.
```