### PR TITLE
Fix/216 missing return statements

### DIFF
--- a/src/DuckEsp.cpp
+++ b/src/DuckEsp.cpp
@@ -3,7 +3,7 @@
 namespace duckesp {
 #ifdef ESP32
 void restartDuck() { ESP.restart(); }
-int freeHeapMemory() {ESP.getFreeHeap();}
+int freeHeapMemory() {return ESP.getFreeHeap();}
 #else 
 void restartDuck() {}
 int freeHeapMemory() {}

--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -282,6 +282,7 @@ int DuckNet::saveWifiCredentials(String ssid, String password) {
     }
     EEPROM.commit();
   }
+  return DUCK_ERR_NONE;
 }
 
   int DuckNet::loadWiFiCredentials(){
@@ -314,7 +315,7 @@ int DuckNet::saveWifiCredentials(String ssid, String password) {
     loginfo("Setup Internet with saved credentials");
     setupInternet(esid, epass);
   }
-
+  return DUCK_ERR_NONE;
 }
 
 

--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -6,7 +6,7 @@
 namespace duckutils {
 
   namespace {
-    std::string cdpVersion = "2.9.12";
+    std::string cdpVersion = "2.9.13";
   }
 
 volatile bool interruptEnabled = true;

--- a/src/Ducks/Duck.cpp
+++ b/src/Ducks/Duck.cpp
@@ -375,8 +375,7 @@ String Duck::getErrorString(int error) {
       return errorStr + "Internet SSID is not valid";
     case DUCK_INTERNET_ERR_CONNECT:
       return errorStr + "Internet connection failed";
-
-    defaut:
-      return "Unknown error";
   }
+  
+  return "Unknown error";
 }

--- a/src/include/DuckNet.h
+++ b/src/include/DuckNet.h
@@ -11,8 +11,7 @@
  * @copyright
  */
 
-#ifndef DUCKNET_H_
-#define DUCKNET_H_
+#pragma once
 
 #include "cdpcfg.h"
 #include <WString.h>
@@ -137,25 +136,27 @@ public:
    */
   bool ssidAvailable(String val = "");
 
-  /**
-   * @brief Set the WiFi network ssid.
-   *
-   * @param val the ssid string to set
-   */
-
-  int saveWifiCredentials(String ssid, String password);
+  
   /**
    * @brief Save / Write Wifi credentials to EEPROM
    *
    * @param ssid        the ssid of the WiFi network
    * @param password    password to join the network
+   * @return DUCK_ERR_NONE if successful, an error code otherwise.
    */
-
-  int loadWiFiCredentials();
+  int saveWifiCredentials(String ssid, String password);
+  
   /**
    * @brief Load Wifi credentials from EEPROM
+   * @return DUCK_ERR_NONE if successful, an error code otherwise.
    */
-
+  int loadWiFiCredentials();
+  
+  /**
+   * @brief Set the WiFi network ssid.
+   *
+   * @param val the ssid string to set
+   */
   void setSsid(String val);
 
   /**
@@ -213,5 +214,3 @@ private:
   String ssid = "";
   String password = "";
 };
-
-#endif


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
- Fixed a number of methods in DuckNet.cpp and DuckEsp.cpp that were missing return statements
- Fixed mismatched doxygen method headers
- Replaced DuckNet.h header guard with `#pragma once`
- 
**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
https://github.com/Call-for-Code/ClusterDuck-Protocol/issues/216

**Additional context**
These errors were caught after turning Warning to `All` in the Arduino IDE. The compiler in that case will treat some warnings as errors.
