### PR TITLE
removed iostream include from oled devices

### DIFF
--- a/src/DuckDisplay.cpp
+++ b/src/DuckDisplay.cpp
@@ -1,9 +1,6 @@
 #include "DuckDisplay.h"
 
 #ifdef CDPCFG_OLED_CLASS
-// 2021-06-18: Including iostream adds ~169KB to the build.
-#include <iostream>
-
 #include "include/DuckTypes.h"
 #include "include/DuckEsp.h"
 #include "include/DuckUtils.h"


### PR DESCRIPTION
Saves ~169KB of storage space. Similar to PR #215

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
No

**Additional context**
DuckDisplay.cpp is still being compiled because ["source code found in src folder and all its subfolders is compiled and linked in the user’s sketch"](https://arduino.github.io/arduino-cli/latest/library-specification/), but now it's ~169KB smaller (in terms of storage space).