### PR TITLE
Use random(max) as this is supported by all platforms

### DIFF
--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -35,7 +35,7 @@ void  getRandomBytes(int length, byte* bytes) {
   for (i = 0; i < length; i++) {
     //TODO: Random generator here isn't seeded properly
     //We can use RSSI value to seed it or use a frame counter if available
-    bytes[i] = digits[random(0, 35)];
+    bytes[i] = digits[random(36)];    
   }
 }
 
@@ -44,7 +44,7 @@ String createUuid(int length) {
   int i;
 
   for (i = 0; i < length; i++) {
-    byte randomValue = random(0, 36);
+    byte randomValue = random(36);
     if (randomValue < 26) {
       msg = msg + char(randomValue + 'a');
     } else {


### PR DESCRIPTION
Signed-off-by: Amir Nathoo <amir.nth@gmail.com>

**Describe at a high level the solution you're providing**
Updated DuckUtils to use `random(max)` as this is supported by all platforms

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
https://github.com/Call-for-Code/ClusterDuck-Protocol/issues/220

**Additional context**
Tested on the following boards: Heltec WiFi v2, Arduino Zero USB and Heltec CubeCell AB01 
