### PR TITLE
fix volatile qualifier

### DIFF
--- a/src/ClusterDuck.h
+++ b/src/ClusterDuck.h
@@ -64,7 +64,7 @@ public:
    * 
    * @return true if interrupt is enabled, false otherwise.
    */
-  volatile bool getInterrupt();
+  bool getInterrupt();
 
   /**
    * @brief Toggle the flag that indicates a message is received.
@@ -164,7 +164,7 @@ public:
    * 
    * @return true if a received packet is available, false otherwise. 
    */
-  volatile bool getFlag();
+  bool getFlag();
 
   /**
    * @brief Set the Duck to be ready to recieve LoRa packets.

--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -13,7 +13,7 @@ volatile bool interruptEnabled = true;
 Timer<> duckTimer = timer_create_default();
 bool detectState = false;
 
-volatile bool isInterruptEnabled() { return interruptEnabled; }
+bool isInterruptEnabled() { return interruptEnabled; }
 void setInterrupt(bool enable) { interruptEnabled = enable; }
 
 std::string getCDPVersion() {

--- a/src/include/DuckUtils.h
+++ b/src/include/DuckUtils.h
@@ -54,7 +54,7 @@ String convertToHex(byte* data, int size);
  * 
  * @returns true if interrupt is enabled, false otherwise.
  */
-volatile bool isInterruptEnabled();
+bool isInterruptEnabled();
 
 /**
  * @brief Toggle the duck Interrupt


### PR DESCRIPTION
Fixes warning when using verbose compilation. volatile is ignored when it's declared as part of the return type of a function, and that makes sense because it's returning a copy of the volatile variable.

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
No

**Additional context**
Verbose compilation should be used more often. It catches real issues, like the missing returns that @amirna2 recently fixed in #217.