### PR TITLE
src: output warning if heap runs low on memory

### DIFF
--- a/src/DuckEsp.cpp
+++ b/src/DuckEsp.cpp
@@ -4,9 +4,13 @@ namespace duckesp {
 #ifdef ESP32
 void restartDuck() { ESP.restart(); }
 int freeHeapMemory() {return ESP.getFreeHeap();}
+int getMinFreeHeap() { return ESP.getMinFreeHeap(); }
+int getMaxAllocHeap() { return ESP.getMaxAllocHeap(); }
 #else 
 void restartDuck() {}
 int freeHeapMemory() {}
+int getMinFreeHeap() {}
+int getMaxAllocHeap() {}
 #endif
 
 #ifdef ESP32

--- a/src/Ducks/Duck.cpp
+++ b/src/Ducks/Duck.cpp
@@ -1,6 +1,8 @@
 #include "include/Duck.h"
 #include "include/DuckEsp.h"
+#include "../CdpPacket.h"
 
+const int MEMORY_LOW_THRESHOLD = PACKET_LENGTH + sizeof(CdpPacket);
 volatile bool Duck::receivedFlag = false;
 
 Duck::Duck(String name) {
@@ -26,6 +28,14 @@ void Duck::encrypt(uint8_t* text, uint8_t* encryptedData, size_t inc) {
 
 void Duck::decrypt(uint8_t* encryptedData, uint8_t* text, size_t inc) {
   duckcrypto::decryptData(encryptedData, text, inc);
+}
+
+void Duck::logIfLowMemory() {
+  if (duckesp::getMinFreeHeap() < MEMORY_LOW_THRESHOLD
+    || duckesp::getMaxAllocHeap() < MEMORY_LOW_THRESHOLD
+  ) {
+    logwarn("WARNING heap memory is low");
+  }
 }
 
 int Duck::setDeviceId(std::vector<byte> id) {

--- a/src/Ducks/DuckDetect.cpp
+++ b/src/Ducks/DuckDetect.cpp
@@ -44,6 +44,9 @@ int DuckDetect::setupWithDefaults(std::vector<byte> deviceId, String ssid,
 }
 
 void DuckDetect::run() {
+  
+  Duck::logIfLowMemory();
+  
   handleOtaUpdate();
   if (getReceiveFlag()) {
     setReceiveFlag(false);

--- a/src/Ducks/DuckLink.cpp
+++ b/src/Ducks/DuckLink.cpp
@@ -43,6 +43,9 @@ int DuckLink::setupWithDefaults(std::vector<byte> deviceId, String ssid,
 }
 
 void DuckLink::run() {
+  
+  Duck::logIfLowMemory();
+  
   duckRadio->processRadioIrq();
   handleOtaUpdate();
   processPortalRequest();

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -44,7 +44,9 @@ int MamaDuck::setupWithDefaults(std::vector<byte> deviceId, String ssid, String 
 }
 
 void MamaDuck::run() {
-
+  
+  Duck::logIfLowMemory();
+  
   handleOtaUpdate();
   if (getReceiveFlag()) {
     duckutils::setInterrupt(false);

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -74,7 +74,9 @@ int PapaDuck::setupWithDefaults(std::vector<byte> deviceId, String ssid,
 }
 
 void PapaDuck::run() {
-
+  
+  Duck::logIfLowMemory();
+  
   handleOtaUpdate();
   if (getReceiveFlag()) {
     duckutils::setInterrupt(false);

--- a/src/include/Duck.h
+++ b/src/include/Duck.h
@@ -340,6 +340,11 @@ protected:
    */
   void handleOtaUpdate();
 
+  /**
+   * @brief Log an error message if the system's memory is too low.
+   */
+  static void logIfLowMemory();
+
   static volatile bool receivedFlag;
   static void setReceiveFlag(bool value) { receivedFlag = value; }
   static bool getReceiveFlag() { return receivedFlag; }

--- a/src/include/DuckEsp.h
+++ b/src/include/DuckEsp.h
@@ -25,6 +25,20 @@ namespace duckesp {
 int freeHeapMemory();
 
 /**
+ * @brief Get lowest level of free heap since boot
+ * 
+ * @returns memory size in bytes
+ */
+int getMinFreeHeap();
+
+/**
+ * @brief Get largest block of heap that can be allocated at once
+ * 
+ * @returns memory size in bytes
+ */
+int getMaxAllocHeap();
+
+/**
  * @brief Restart the duck device.
  * 
  */


### PR DESCRIPTION
Logs warnings to the device's serial output when the heap memory
is too low to allocate a new Cdp packet.

Fixes: https://github.com/Call-for-Code/ClusterDuck-Protocol/issues/237


