### PR TITLE
src: move EEPROM methods from DuckNet to DuckUtils

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on our Code of Conduc
 This project is licensed under the Apache 2 License - see the [LICENSE](LICENSE) file for details.
 
 ## Version
-v2.10.2
+v2.10.3
 
 
 [Project OWL]: <https://www.project-owl.com/>

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
         "email": "info@project-owl.com",
         "url": "https://www.project-owl.com"
     },
-    "version": "2.10.2",
+    "version": "2.10.3",
     "repository":
     {
         "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ClusterDuck Protocol
-version=2.10.2
+version=2.10.3
 author=Project OWL <info@project-owl.com>
 maintainer=Project OWL <info@project-owl.com>
 sentence=Mesh communication protocol.

--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -243,7 +243,9 @@ int DuckNet::setupWebServer(bool createCaptivePortal, String html) {
 
     if (ssid != "" && password != "") {
       setupInternet(ssid, password);
-      saveWifiCredentials(ssid, password);
+      this->ssid = ssid;
+      this->password = password;
+      duckutils::saveWifiCredentials(ssid, password);
       request->send(200, "text/plain", "Success");
     } else {
       request->send(500, "text/plain", "There was an error");
@@ -300,67 +302,16 @@ int DuckNet::setupDns() {
   return DUCK_ERR_NONE;
 }
 
-int DuckNet::saveWifiCredentials(String ssid, String password) {
-  this->ssid = ssid;
-  this->password = password;
+int DuckNet::loadWiFiCredentials(){
+  setSsid(duckutils::loadWifiSsid());
+  setPassword(duckutils::loadWifiPassword());
 
-
-  EEPROM.begin(512);
-
-  if (ssid.length() > 0 && password.length() > 0) {
-    loginfo("Clearing EEPROM");
-    for (int i = 0; i < 96; i++) {
-      EEPROM.write(i, 0);
-    }
-
-    loginfo("writing EEPROM SSID:");
-    for (int i = 0; i < ssid.length(); i++)
-    {
-      EEPROM.write(i, ssid[i]);
-      loginfo("Wrote: ");
-      loginfo(ssid[i]);
-    }
-    loginfo("writing EEPROM Password:");
-    for (int i = 0; i < password.length(); ++i)
-    {
-      EEPROM.write(32 + i, password[i]);
-      loginfo("Wrote: ");
-      loginfo(password[i]);
-    }
-    EEPROM.commit();
-  }
-  return DUCK_ERR_NONE;
-}
-
-  int DuckNet::loadWiFiCredentials(){
-
-  // This method will look for any saved WiFi credntials on the device and set up a internet connection
-  EEPROM.begin(512); //Initialasing EEPROM
-
-  String esid;
-  for (int i = 0; i < 32; ++i)
-  {
-    esid += char(EEPROM.read(i));
-  }
-  // lopp through saved SSID carachters
-  loginfo("Reading EEPROM SSID: " + esid);
-  setSsid(esid);
-
-  String epass = "";
-  for (int i = 32; i < 96; ++i)
-  {
-    epass += char(EEPROM.read(i));
-  }
-  // lopp through saved Password carachters
-  loginfo("Reading EEPROM Password: " + epass);
-  setPassword(epass);
-
-  if (esid.length() == 0 || epass.length() == 0){
+  if (ssid.length() == 0 || password.length() == 0){
     loginfo("ERROR setupInternet: Stored SSID and PASSWORD empty");
     return DUCK_ERR_SETUP;
   } else{
     loginfo("Setup Internet with saved credentials");
-    setupInternet(esid, epass);
+    setupInternet(ssid, password);
   }
   return DUCK_ERR_NONE;
 }

--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -3,6 +3,8 @@
 #include <sstream>
 #include <string>
 
+#include "DuckLogger.h"
+
 namespace duckutils {
 
   namespace {
@@ -70,6 +72,58 @@ uint32_t toUnit32(const byte* data) {
     value |= data[2] << 8;
     value |= data[3];
     return value;
+}
+
+int saveWifiCredentials(String ssid, String password) {
+  EEPROM.begin(512);
+
+  if (ssid.length() > 0 && password.length() > 0) {
+    loginfo("Clearing EEPROM");
+    for (int i = 0; i < 96; i++) {
+      EEPROM.write(i, 0);
+    }
+
+    loginfo("writing EEPROM SSID:");
+    for (int i = 0; i < ssid.length(); i++)
+    {
+      EEPROM.write(i, ssid[i]);
+      loginfo("Wrote: ");
+      loginfo(ssid[i]);
+    }
+    loginfo("writing EEPROM Password:");
+    for (int i = 0; i < password.length(); ++i)
+    {
+      EEPROM.write(32 + i, password[i]);
+      loginfo("Wrote: ");
+      loginfo(password[i]);
+    }
+    EEPROM.commit();
+  }
+  return DUCK_ERR_NONE;
+}
+
+String loadWifiSsid() {
+  EEPROM.begin(512); //Initialasing EEPROM
+  String esid;
+  // loop through saved SSID characters
+  for (int i = 0; i < 32; ++i)
+  {
+    esid += char(EEPROM.read(i));
+  }
+  loginfo("Reading EEPROM SSID: " + esid);
+  return esid;
+}
+
+String loadWifiPassword() {
+  EEPROM.begin(512); //Initialasing EEPROM
+  String epass = "";
+  // loop through saved Password characters
+  for (int i = 32; i < 96; ++i)
+  {
+    epass += char(EEPROM.read(i));
+  }
+  loginfo("Reading EEPROM Password: " + epass);
+  return epass;
 }
 
 } // namespace duckutils

--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -8,7 +8,7 @@
 namespace duckutils {
 
   namespace {
-    std::string cdpVersion = "2.10.2";
+    std::string cdpVersion = "2.10.3";
   }
 
 Timer<> duckTimer = timer_create_default();

--- a/src/include/DuckNet.h
+++ b/src/include/DuckNet.h
@@ -34,7 +34,6 @@ class DuckNet;
 #include <ESPmDNS.h>
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
-#include <EEPROM.h>
 
 #include "../DuckError.h"
 #include "DuckEsp.h"
@@ -131,16 +130,6 @@ public:
    */
   bool ssidAvailable(String val = "");
 
-  
-  /**
-   * @brief Save / Write Wifi credentials to EEPROM
-   *
-   * @param ssid        the ssid of the WiFi network
-   * @param password    password to join the network
-   * @return DUCK_ERR_NONE if successful, an error code otherwise.
-   */
-  int saveWifiCredentials(String ssid, String password);
-  
   /**
    * @brief Load Wifi credentials from EEPROM
    * @return DUCK_ERR_NONE if successful, an error code otherwise.

--- a/src/include/DuckUtils.h
+++ b/src/include/DuckUtils.h
@@ -13,9 +13,12 @@
 #include "cdpcfg.h"
 #include "arduino-timer.h"
 #include <Arduino.h>
+#include <EEPROM.h>
 #include <string>
 #include <WString.h>
 #include <vector>
+
+#include "../DuckError.h"
 
 namespace duckutils {
 
@@ -95,6 +98,29 @@ Timer<> getTimer();
 
 bool getDetectState();
 bool flipDetectState();
+
+/**
+ * @brief Save / Write Wifi credentials to EEPROM
+ *
+ * @param ssid        the ssid of the WiFi network
+ * @param password    password to join the network
+ * @return DUCK_ERR_NONE if successful, an error code otherwise.
+ */
+int saveWifiCredentials(String ssid, String password);
+
+/**
+ * @brief Load WiFi SSID from EEPROM
+ *
+ * @returns A string representing the WiFi SSID
+ */
+String loadWifiSsid();
+
+/**
+ * @brief Load WiFi password from EEPROM
+ *
+ * @returns A string representing the WiFi password
+ */
+String loadWifiPassword();
 
 } // namespace duckutils
 #endif


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
* Move the functionality of saving the WiFi credentials to EEPROM to
the saveWifiCredentials function in DuckUtils
* Move the functionality of loading the WiFi credentials from EEPROM to
the loadWifiSsid and loadWifiPassword functions in DuckUtils

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
https://github.com/Call-for-Code/ClusterDuck-Protocol/issues/231