### PR TITLE
missing preposition in line 16 of Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The network is made up of multiple nodes called **"Ducks"**. There are 3 core ro
 ![overview](https://www.project-owl.com/assets/wiki/cdp-explain-gif.gif)
 
 ## Captive Portal
-The Captive Portal is an important feature in the ClusterDuck Protocol network. The Captive Portal allows devices such as smartphones and laptops to access the network without the need to download additional software as it takes advantage a system that is native to smartphones such as Android and iPhone devices and laptops. 
+The Captive Portal is an important feature in the ClusterDuck Protocol network. The Captive Portal allows devices such as smartphones and laptops to access the network without the need to download additional software as it takes advantage of a system that is native to smartphones such as Android and iPhone devices and laptops. 
 
 This is beneficial after events such as earthquakes or hurricanes where traditional communication infrastructure is crippled. Users are able to connect to the WiFi access point of a DuckLink or MamaDuck which will in turn relay their message onward.
 


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
There is a grammatical error in the read me. It is missing the preposition "of" in line 16  between "advantage "and "a".
_" as it takes advantage _ a system..."_

**Is this a patch, a minor version change, or a major version change**
Extremely minor change to the readme.

**Is this related to an open issue?**
No.

**Additional context**
Grammatical correction.
