### PR TITLE
Fix PIO build errors

### DIFF
--- a/examples/1.Ducks/MamaDuck/platformio.ini
+++ b/examples/1.Ducks/MamaDuck/platformio.ini
@@ -18,10 +18,16 @@ framework = arduino
 monitor_speed = 115200
 monitor_filters = time
 
-lib_deps = 
-    ClusterDuck Protocol
-    ; /PATH-TO/ClusterDuck-Protocol
-    
+lib_deps =
+    https://github.com/Call-for-Code/ClusterDuck-Protocol
+    https://github.com/Project-Owl/Crypto.git
+    jgromes/RadioLib @ 4.1.0
+    olikraus/U8g2 @ ^2.32.6
+    contrem/arduino-timer @ ^2.3.0
+    me-no-dev/ESP Async WebServer @ ~1.2.3
+    bakercp/CRC32 @ ^2.0.0
+    Update
+    ArduinoOTA
 
 ; uncommend for OTA update
 ; upload_port = duck.local

--- a/examples/1.Ducks/PapaDuck/platformio.ini
+++ b/examples/1.Ducks/PapaDuck/platformio.ini
@@ -21,8 +21,17 @@ monitor_filters = time
 
 
 lib_deps = 
-    ; ClusterDuck Protocol
+    https://github.com/Call-for-Code/ClusterDuck-Protocol
     https://github.com/Project-Owl/Crypto.git
+    jgromes/RadioLib @ 4.1.0
+    olikraus/U8g2 @ ^2.32.6
+    contrem/arduino-timer @ ^2.3.0
+    me-no-dev/ESP Async WebServer @ ~1.2.3
+    bakercp/CRC32 @ ^2.0.0
+    Update
+    ArduinoOTA
+    ArduinoJson
+    knolleary/PubSubClient @ 2.8
 
 
 ; uncommend for OTA update


### PR DESCRIPTION
This commit is able to successfully build MamaDuck and PapaDuck.

**Is this a patch, a minor version change, or a major version change**
Patch.

**Additional context**
There are known issues that have easy fixes:
- While Compiling MamaDuck, an error may appear in AES.h. the fix is to
  comment out #if part and only keep the define under #else.
- Other examples than PapaDuck and MamaDuck may have different lib_deps.
  But this should be a matter of just adding libraries to pio.ini files
  of respective examples.

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>