### PR TITLE
Fix board configuration typos in TTGO T-Beam

### DIFF
--- a/src/include/cdpcfg.h
+++ b/src/include/cdpcfg.h
@@ -92,7 +92,7 @@
 #define CDPCFG_PIN_LORA_DIO1 -1
 
 // T-Beam
- #elif defined(ARDUINO_TBeam)
+ #elif defined(ARDUINO_T_Beam)
   #define CDPCFG_PIN_BAT 35 
   #define CDPCFG_BAT_MULDIV 200 / 100 
   #define CDPCFG_PIN_LED1 25 
@@ -101,8 +101,8 @@
   #define CDPCFG_PIN_LORA_DIO0 26 
   #define CDPCFG_PIN_LORA_RST 14 
   // Oled Display settings 
-  #define CDPCFG_PIN_OLED_CLOCK 21
-  #define CDPCFG_PIN_OLED_DATA 22
+  #define CDPCFG_PIN_OLED_CLOCK 22
+  #define CDPCFG_PIN_OLED_DATA 21
   #define CDPCFG_PIN_OLED_RESET 16 
   #define CDPCFG_PIN_OLED_ROTATION U8G2_R0 
   // actualy missing 


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
This addresses two fixes for the TTGO T-Beam,
1. The compiler flag was incorrect, which caused build issues and the board defaulted to a Heltec board.
2. The OLED SDA/SCL pins were backwards, which caused the OLED to not properly initialize.

**Is this a patch, a minor version change, or a major version change**
Patch

**Is this related to an open issue?**
No

**Additional context**
Issues which lead to my patch were observed using a LILYGO TTGO T-Beam in PlatformIO
