### PR TITLE
Public and Private Chat Feature Between Ducks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This project is licensed under the Apache 2 License - see the [LICENSE](LICENSE)
 
 ## Version
 
-v3.2.5
+v3.3.5
 
 
 

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
         "email": "info@project-owl.com",
         "url": "https://www.project-owl.com"
     },
-    "version": "3.2.5",
+    "version": "3.3.5",
     "repository":
     {
         "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ClusterDuck Protocol
-version=3.2.5
+version=3.3.5
 author=Project OWL <info@project-owl.com>
 maintainer=Project OWL <info@project-owl.com>
 sentence=Mesh communication protocol.

--- a/src/CdpPacket.h
+++ b/src/CdpPacket.h
@@ -96,8 +96,10 @@ enum topics {
   health = 0x15,
   // Send duck commands
   dcmd = 0x16,
-  //chat message
-  chat = 0x17,
+  //global chat message
+  gchat = 0x17,
+  //private chat message
+  pchat = 0x18,
   // MQ7 Gas Sensor
   mq7 = 0xEF,
   // GP2Y Dust Sensor

--- a/src/CdpPacket.h
+++ b/src/CdpPacket.h
@@ -96,6 +96,8 @@ enum topics {
   health = 0x15,
   // Send duck commands
   dcmd = 0x16,
+  //chat message
+  chat = 0x17,
   // MQ7 Gas Sensor
   mq7 = 0xEF,
   // GP2Y Dust Sensor
@@ -203,6 +205,12 @@ public:
     return duckutils::convertToHex(path.data(), path.size());
   }
 
+  std::vector<byte> converToBuffer(){
+    std::vector<byte> sendBuffer;
+    sendBuffer.insert(sendBuffer.end(), sduid.begin(), sduid.end());
+    //sendBuffer.pushback for topic
+    return sendBuffer;
+  }
   /**
    * @brief Resets the cdp packet and underlying byte buffers.
    *

--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -122,7 +122,6 @@ std::string DuckNet::retrieveMessageHistory(CircularBuffer* buffer)
     CdpPacket packet = buffer->getMessage(tail);
     unsigned long messageAge = millis() - packet.timeReceived;
     std::string messageAgeString = String(messageAge).c_str();
-    loginfo(String(messageAge).c_str());
     std::string messageBody(packet.data.begin(),packet.data.end());
     std::string sduid(packet.sduid.begin(), packet.sduid.end());
 

--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -98,10 +98,8 @@ void DuckNet::addToPrivateChatBuffer(CdpPacket message, std::string chatSession)
 void DuckNet::createPrivateHistory(std::string session)
 {
   if(chatHistories.find(session) == chatHistories.end()){
-    loginfo("creating chat history");
       CircularBuffer* privateChatBuffer = new CircularBuffer(20);
       if(chatHistories.size() >= 3){
-        loginfo("deleting chat history");
         delete chatHistories.begin()->second;
         chatHistories.erase(chatHistories.begin());
       }
@@ -365,8 +363,6 @@ int DuckNet::setupWebServer(bool createCaptivePortal, String html) {
         json = json + ", ";
       }
       json = json + "\"" +  myPair.first + "\"";
-      loginfo("!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! json !!!!!!!!!!!!!!!!!!!!!!!!!!");
-      loginfo(myPair.first.c_str());
       keyNum++;
     }
     json = json + "]}";

--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -8,7 +8,7 @@
 namespace duckutils {
 
   namespace {
-    std::string cdpVersion = "3.2.5";
+    std::string cdpVersion = "3.3.5";
   }
 
 Timer<> duckTimer = timer_create_default();

--- a/src/Ducks/Duck.cpp
+++ b/src/Ducks/Duck.cpp
@@ -377,6 +377,29 @@ muidStatus Duck::getMuidStatus(const std::vector<byte> & muid) const {
   }
 }
 
+CdpPacket Duck::buildCdpPacket(byte topic, const std::vector<byte> data,
+    const std::vector<byte> targetDevice, const std::vector<byte> &muid)
+{
+  if (data.size() > MAX_DATA_LENGTH)
+  {
+    logerr("ERROR send data failed, message too large: " + String(data.size()) +
+           " bytes");
+    logerr(DUCKPACKET_ERR_SIZE_INVALID);
+  }
+  int err = txPacket->prepareForSending(&filter, targetDevice, this->getType(), topic, data);
+  //txPacket unintended side effects?
+
+  if (err != DUCK_ERR_NONE)
+  {
+    logerr("prepare for sending failed. " + err);
+  }
+  //todo error not handled properly
+  CdpPacket packet = CdpPacket(txPacket->getBuffer());
+  packet.muid = muid;
+
+  return packet;
+}
+
 // TODO: implement this using new packet format
 bool Duck::reboot(void*) {
   /*

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -186,8 +186,6 @@ void MamaDuck::handleReceivedPacket() {
         break;
         case topics::pchat:{
           packet.timeReceived = millis();
-          loginfo("!!!!!!!!!!!!!!!!!!!!!!!!!!------- DUCKINFO -----!!!!!!!!!!!!!!!!!!");
-          loginfo(duckNet->duckSession.c_str());
           std::string session(packet.sduid.begin(), packet.sduid.end());
 
           duckNet->createPrivateHistory(session);

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -90,7 +90,6 @@ void MamaDuck::handleReceivedPacket() {
 
     //Check if Duck is desitination for this packet before relaying
     if (duckutils::isEqual(BROADCAST_DUID, packet.dduid)) {
-      
       switch(packet.topic) {
         case reservedTopic::ping:
           loginfo("ping received");
@@ -122,11 +121,12 @@ void MamaDuck::handleReceivedPacket() {
           }
         break;
         case reservedTopic::mbm:
-        {
-          CdpPacket packet = CdpPacket(rxPacket->getBuffer());
           packet.timeReceived = millis();
-          duckNet->addMessageToBuffer(packet);
-        }
+          duckNet->addToMessageBoardBuffer(packet);
+        break;
+        case topics::chat:
+          packet.timeReceived = millis();
+          duckNet->addToChatBuffer(packet);
         break;
         default:
           err = duckRadio.relayPacket(rxPacket);
@@ -163,7 +163,6 @@ void MamaDuck::handleReceivedPacket() {
 
           err = duckRadio.sendData(txPacket->getBuffer());
           if (err == DUCK_ERR_NONE) {
-            CdpPacket packet = CdpPacket(txPacket->getBuffer());
             filter.bloom_add(packet.muid.data(), MUID_LENGTH);
           } else {
             logerr("ERROR handleReceivedPacket. Failed to send ack. Error: " +
@@ -178,11 +177,12 @@ void MamaDuck::handleReceivedPacket() {
           handleAck(packet);
         break;
         case reservedTopic::mbm:
-        {
-          CdpPacket packet = CdpPacket(rxPacket->getBuffer());
           packet.timeReceived = millis();
-          duckNet->addMessageToBuffer(packet);
-        }
+          duckNet->addToMessageBoardBuffer(packet);
+        break;
+        case topics::chat:
+          packet.timeReceived = millis();
+          duckNet->addToChatBuffer(packet);
         break;
         default:
           err = duckRadio.relayPacket(rxPacket);

--- a/src/Ducks/MamaDuck.cpp
+++ b/src/Ducks/MamaDuck.cpp
@@ -124,7 +124,7 @@ void MamaDuck::handleReceivedPacket() {
           packet.timeReceived = millis();
           duckNet->addToMessageBoardBuffer(packet);
         break;
-        case topics::chat:
+        case topics::gchat:
           packet.timeReceived = millis();
           duckNet->addToChatBuffer(packet);
         break;
@@ -180,9 +180,19 @@ void MamaDuck::handleReceivedPacket() {
           packet.timeReceived = millis();
           duckNet->addToMessageBoardBuffer(packet);
         break;
-        case topics::chat:
+        case topics::gchat:
           packet.timeReceived = millis();
           duckNet->addToChatBuffer(packet);
+        break;
+        case topics::pchat:{
+          packet.timeReceived = millis();
+          loginfo("!!!!!!!!!!!!!!!!!!!!!!!!!!------- DUCKINFO -----!!!!!!!!!!!!!!!!!!");
+          loginfo(duckNet->duckSession.c_str());
+          std::string session(packet.sduid.begin(), packet.sduid.end());
+
+          duckNet->createPrivateHistory(session);
+          duckNet->addToPrivateChatBuffer(packet, session);
+        }
         break;
         default:
           err = duckRadio.relayPacket(rxPacket);

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -120,7 +120,7 @@ void PapaDuck::handleReceivedPacket() {
         rxPacket->getBuffer().size()));
     loginfo("invoking callback in the duck application...");
     
-    if(rxPacket->getTopic() == topics::chat){
+    if(rxPacket->getTopic() == topics::gchat){
       duckNet->addToChatBuffer(CdpPacket(rxPacket->getBuffer()));
     } else{
       recvDataCallback(rxPacket->getBuffer());

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -126,7 +126,6 @@ void PapaDuck::handleReceivedPacket() {
       recvDataCallback(rxPacket->getBuffer());
     }
     
-
     if (acksEnabled) {
       const CdpPacket packet = CdpPacket(rxPacket->getBuffer());
       if (needsAck(packet)) {

--- a/src/Ducks/PapaDuck.cpp
+++ b/src/Ducks/PapaDuck.cpp
@@ -120,7 +120,12 @@ void PapaDuck::handleReceivedPacket() {
         rxPacket->getBuffer().size()));
     loginfo("invoking callback in the duck application...");
     
-    recvDataCallback(rxPacket->getBuffer());
+    if(rxPacket->getTopic() == topics::chat){
+      duckNet->addToChatBuffer(CdpPacket(rxPacket->getBuffer()));
+    } else{
+      recvDataCallback(rxPacket->getBuffer());
+    }
+    
 
     if (acksEnabled) {
       const CdpPacket packet = CdpPacket(rxPacket->getBuffer());

--- a/src/circularBuffer.cpp
+++ b/src/circularBuffer.cpp
@@ -35,7 +35,7 @@ CdpPacket CircularBuffer::getMessage(int index)
 }
 CircularBuffer::~CircularBuffer()
 {
-    delete buffer;
+    delete [] buffer;
 }
 
 

--- a/src/include/Duck.h
+++ b/src/include/Duck.h
@@ -212,7 +212,7 @@ public:
    * @param length the length of the byte buffer
    * @param targetDevice the device UID to receive the message
    * @param muid the muid that should be associated with this packet
-   * @return 
+   * @return a new CdpPacket
    * */
   CdpPacket buildCdpPacket(byte topic, const std::vector<byte> data,
     const std::vector<byte> targetDevice, const std::vector<byte> &muid);

--- a/src/include/Duck.h
+++ b/src/include/Duck.h
@@ -205,6 +205,19 @@ public:
     const std::vector<byte> targetDevice = ZERO_DUID, std::vector<byte> * outgoingMuid = NULL);
 
   /**
+   * @brief Builds a CdpPacket with a specified muid.
+   *
+   * @param topic the message topic
+   * @param data a byte buffer representing the data to send
+   * @param length the length of the byte buffer
+   * @param targetDevice the device UID to receive the message
+   * @param muid the muid that should be associated with this packet
+   * @return 
+   * */
+  CdpPacket buildCdpPacket(byte topic, const std::vector<byte> data,
+    const std::vector<byte> targetDevice, const std::vector<byte> &muid);
+
+  /**
    * @brief Updates the firmware on the device
    *
    * TODO: Additional documentation

--- a/src/include/DuckNet.h
+++ b/src/include/DuckNet.h
@@ -134,7 +134,19 @@ public:
    */
   void addToPrivateChatBuffer(CdpPacket message, std::string chatSession);
 
+   /**
+   * @brief creates a new private chat history, replacing the oldest history if the limit is reached.
+   *
+   * @param session the destination device to open a chat with
+   */
   void createPrivateHistory(std::string session);
+
+  /**
+   * @brief retrieve all messages from from message circular buffer
+   *
+   * @returns a json array of messages with a title, body, and messageAge
+   */
+  std::string retrieveMessageHistory(CircularBuffer* buffer);
 
   /**
    * @brief Set up the WiFi access point.
@@ -270,12 +282,4 @@ private:
   String password = "";
   // char* controlSsid = "";
   // char* controlPassword = "";
-
-
-    /**
-   * @brief retrieve all messages from from message circular buffer
-   *
-   * @returns a json array of messages with a title, body, and messageAge
-   */
-  std::string retrieveMessageHistory(CircularBuffer* buffer);
 };

--- a/src/include/DuckNet.h
+++ b/src/include/DuckNet.h
@@ -64,6 +64,7 @@ class DuckNet {
 public:
 
   int channel;
+  std::string duckSession;
 
 #ifdef CDPCFG_WIFI_NONE
   int setupWebServer(bool createCaptivePortal = false, String html = "") {
@@ -132,6 +133,8 @@ public:
    * @param chatSession the session of the chat buffer you want to add to.
    */
   void addToPrivateChatBuffer(CdpPacket message, std::string chatSession);
+
+  void createPrivateHistory(std::string session);
 
   /**
    * @brief Set up the WiFi access point.

--- a/src/include/DuckNet.h
+++ b/src/include/DuckNet.h
@@ -34,6 +34,7 @@ class DuckNet;
 #include <ESPmDNS.h>
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
+#include <map>
 
 #include "../DuckError.h"
 #include "DuckEsp.h"
@@ -122,6 +123,15 @@ public:
    * @param message the packet to add to the buffer
    */
   void addToChatBuffer(CdpPacket message);
+
+  /**
+   * @brief insert received packet into the private chat circular buffer and
+   * send refresh page event to client
+   *
+   * @param message the packet to add to the buffer
+   * @param chatSession the session of the chat buffer you want to add to.
+   */
+  void addToPrivateChatBuffer(CdpPacket message, std::string chatSession);
 
   /**
    * @brief Set up the WiFi access point.

--- a/src/include/DuckNet.h
+++ b/src/include/DuckNet.h
@@ -45,6 +45,9 @@ class DuckNet;
 #include "cdpHome.h"
 #include "papaHome.h"
 #include "messageBoard.h"
+#include "chatPage.h"
+#include "privateChat.h"
+#include "privateChatPrompt.h"
 #include "circularBuffer.h"
 
 #endif
@@ -105,19 +108,20 @@ public:
   int setupWebServer(bool createCaptivePortal = false, String html = "");
 
   /**
-   * @brief insert received packet into the message circular buffer and
+   * @brief insert received packet into the message board circular buffer and
    * send refresh page event to client
    *
    * @param message the packet to add to the buffer
    */
-  void addMessageToBuffer(CdpPacket message);
-  
+  void addToMessageBoardBuffer(CdpPacket message);
+
   /**
-   * @brief retrieve all messages from from message circular buffer
+   * @brief insert received packet into the chat circular buffer and
+   * send refresh page event to client
    *
-   * @returns a json array of messages with a title, body, and messageAge
+   * @param message the packet to add to the buffer
    */
-  std::string retrieveMessageHistory();
+  void addToChatBuffer(CdpPacket message);
 
   /**
    * @brief Set up the WiFi access point.
@@ -253,4 +257,12 @@ private:
   String password = "";
   // char* controlSsid = "";
   // char* controlPassword = "";
+
+
+    /**
+   * @brief retrieve all messages from from message circular buffer
+   *
+   * @returns a json array of messages with a title, body, and messageAge
+   */
+  std::string retrieveMessageHistory(CircularBuffer* buffer);
 };

--- a/src/include/cdpHome.h
+++ b/src/include/cdpHome.h
@@ -16,6 +16,8 @@ const char home_page[] PROGMEM = R"=====(
 		<a href="/controlpanel">Control Panel</a>
 		<a href="/main">Send Message</a>
 		<a href="/message-board">Message Board</a>
+		<a href="/chat">Global Chat</a>
+		<a href="/new-private-chat">Start a Private Chat</a>
 	</div>
   </body>
 </html>

--- a/src/include/chatPage.h
+++ b/src/include/chatPage.h
@@ -117,6 +117,7 @@ const char chat_page[] PROGMEM = R"=====(
             
             requestSduid();
             requestChatHistory();
+            document.getElementById("chatMessage").focus();
         </script>
     </body>
 </html>

--- a/src/include/chatPage.h
+++ b/src/include/chatPage.h
@@ -47,7 +47,7 @@ const char chat_page[] PROGMEM = R"=====(
                 
             }
             function sduidListener () {
-                sduid = JSON.parse(this.responseText);
+                sduid = this.responseText;
             }
 
             function requestChatHistory(){
@@ -91,6 +91,8 @@ const char chat_page[] PROGMEM = R"=====(
                 req.open("POST", "/chatSubmit.json?" + params.toString());
                 req.send();
                 displayNewMessage({body: message.value, messageAge: 0, sduid: sduid}, true);
+
+                message.value = "";
             }
             
             if (!!window.EventSource) {

--- a/src/include/chatPage.h
+++ b/src/include/chatPage.h
@@ -1,0 +1,202 @@
+#ifndef CHAT_PAGE_H
+#define CHAT_PAGE_H
+
+const char chat_page[] PROGMEM = R"=====(
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Global Chat</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+
+    <body>
+    <nav class="title-bar"><span id="title">GLOBAL NETWORK CHAT</span></nav>
+        <div id="message-container"></div>
+        <div class="chat-bar">
+            <div id="form">
+                <form>
+                    <input type="text" name="chatMessage" id="chatMessage" placeholder="Your Message"></input>
+                    <button type="button" id="sendBtn" class="sendBtn">Send</button>
+                    <p id="makeshiftErrorOutput" class="hidden"></p>
+                </form>
+            </div>
+        </div>
+
+        <script>
+            var sduid = "you";
+             function displayNewMessage(newMessage, sent){
+                newMessage.messageAge = parseInt(newMessage.messageAge / 1000);
+                var card = document.createElement("div");
+                if(sent){
+                    card.classList.add("sent-message-card");
+                }else{
+                    card.classList.add("received-message-card");
+                }
+                card.innerHTML = newMessage.body + '</p><span class="duid">FROM DUCKID: '
+                 + newMessage.sduid + '</span></p><span class="time">' 
+                 + newMessage.messageAge + ' seconds ago</span>';
+
+                document.getElementById('message-container').prepend(card);
+            }
+            function chatHistoryListener () {
+                var data = JSON.parse(this.responseText);
+                data.posts.forEach(item => {
+                        let sent = sduid == item.sduid ? true : false;
+                        displayNewMessage(item, sent);
+                    });
+                
+            }
+            function sduidListener () {
+                sduid = JSON.parse(this.responseText);
+            }
+
+            function requestChatHistory(){
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", chatHistoryListener);
+                req.open("GET", "/chatHistory");
+                req.send();
+            }
+
+            function requestSduid(){
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", sduidListener);
+                req.open("GET", "/id");
+                req.send();
+            }
+
+
+
+            function loadListener(){
+                console.log('request returned');
+                var errEl = document.getElementById('makeshiftErrorOutput');
+                if (!errEl.classList.toString().includes("hidden")) {
+                    errEl.innerHTML = '';
+                    errEl.classList.add("hidden");
+                }
+            };
+            function errorListener(){
+                var errorMessage = 'There was an error sending the message. Please try again.';
+                console.log(errorMessage);
+                var errEl = document.getElementById('makeshiftErrorOutput');
+                errEl.innerHTML = errorMessage;
+                errEl.classList.remove("hidden");
+            };
+            function sendMessage(){
+                let message = document.getElementById('chatMessage');
+                let params = new URLSearchParams("");
+                params.append(message.name, message.value);
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", loadListener);
+                req.addEventListener("error", errorListener);
+                req.open("POST", "/chatSubmit.json?" + params.toString());
+                req.send();
+                displayNewMessage({body: message.value, messageAge: 0, sduid: sduid}, true);
+            }
+            
+            if (!!window.EventSource) {
+                var source = new EventSource('/events');
+
+                source.addEventListener('open', function(e) {
+                    console.log("Events Connected");
+                    
+                }, false);
+
+                source.addEventListener('error', function(e) {
+                    if (e.target.readyState != EventSource.OPEN) {
+                    console.log("Events Disconnected");
+                    }
+                }, false);
+                source.addEventListener('refreshPage', function(data) {
+                    location.reload(); 
+                }, false);
+
+            }
+            document.getElementById('sendBtn').addEventListener('click', sendMessage);
+            
+            requestSduid();
+            requestChatHistory();
+        </script>
+    </body>
+</html>
+<style>
+    .received-message-card{
+        border-radius: 10px;
+        background-color: #F0EEF7;
+        padding: 0 3vw 1vh;
+        margin: 2vw;
+        overflow:auto;
+        width: 70%;
+        padding-top: 5px;
+    }
+    .sent-message-card{
+        border-radius: 10px;
+        background-color: #ffff004f;
+        padding: 0 3vw 1vh;
+        margin: 2vw;
+        overflow:auto;
+        width: 70%;
+        float: right;
+        padding-top: 5px;
+    }
+    #message-container{
+        width: 95%;
+        margin: 10vh auto;
+    }
+    .time{
+        margin-right: 3vw;
+        float: right;
+        color: gray;
+        font-size: 0.8em;
+    }
+    .duid{
+        margin-left: 3vw;
+        float: left;
+        color: gray;
+        font-size: 0.8em;
+    }
+    #title{
+        font-size: 1.2em;
+        top: 20%;
+        position: relative;
+        font-weight: bold;
+    }
+    .title-bar{
+        background-color: black;
+        box-shadow: 0 2px 3px gray;
+        height: 35px;
+        position: fixed;
+        top: 0%;
+        width: 100%;
+        color: white;
+        left: 0%;
+        text-align: center;
+    }
+    .chat-bar{
+        background-color: #9b9389;
+        height: 35px;
+        position: fixed;
+        bottom: 0;
+        width: 100%;
+        padding: 5px;
+        left: 0%;
+    }
+    #chatMessage{
+        width: 70%;
+    }
+    #sendBtn{
+        background-color: #ffe700;
+        border-radius: 5px;
+        border-style: none;
+        height: 34px;
+        width: 100px;
+        float: right;
+        margin-right: 15px;
+    }
+    body{
+        font-family: sans-serif;
+        font-size: .9em;
+    }
+
+</style>
+)=====";
+#endif

--- a/src/include/chatPage.h
+++ b/src/include/chatPage.h
@@ -67,7 +67,6 @@ const char chat_page[] PROGMEM = R"=====(
 
 
             function loadListener(){
-                console.log('request returned');
                 var errEl = document.getElementById('makeshiftErrorOutput');
                 if (!errEl.classList.toString().includes("hidden")) {
                     errEl.innerHTML = '';

--- a/src/include/privateChat.h
+++ b/src/include/privateChat.h
@@ -119,6 +119,7 @@ const char private_chat_page[] PROGMEM = R"=====(
             
             requestSduid();
             requestChatHistory();
+            document.getElementById("chatMessage").focus();
         </script>
     </body>
 </html>
@@ -128,21 +129,19 @@ const char private_chat_page[] PROGMEM = R"=====(
     .received-message-card{
         border-radius: 10px;
         background-color: #F0EEF7;
-        padding: 0 3vw 1vh;
+        padding: 5px 3vw 1vh;
         margin: 2vw;
         overflow:auto;
         width: 70%;
-        padding-top: 5px;
     }
     .sent-message-card{
         border-radius: 10px;
         background-color: #ffff004f;
-        padding: 0 3vw 1vh;
+        padding: 5px 3vw 1vh;
         margin: 2vw;
         overflow:auto;
         width: 70%;
         float: right;
-        padding-top: 5px;
     }
     #message-container{
         width: 95%;

--- a/src/include/privateChat.h
+++ b/src/include/privateChat.h
@@ -1,0 +1,205 @@
+#ifndef PRIVATE_CHAT_H
+#define PRIVATE_CHAT_H
+const char private_chat_page[] PROGMEM = R"=====(
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Private Chat</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+
+    <body>
+        <nav class="title-bar"><span id="title">PRIVATE CHAT</span></nav>
+        <div id="chat-display">
+            <div id="message-container"></div>
+            <div class="chat-bar">
+                <div id="form">
+                    <form>
+                        <input type="text" name="chatMessage" id="chatMessage" placeholder="Your Message"></input>
+                        <button type="button" id="sendBtn" class="sendBtn">Send</button>
+                        <p id="makeshiftErrorOutput" class="hidden"></p>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <script>
+            var sduid = "you";
+             function displayNewMessage(newMessage, sent){
+                newMessage.messageAge = parseInt(newMessage.messageAge / 1000);
+                var card = document.createElement("div");
+                if(sent){
+                    card.classList.add("sent-message-card");
+                }else{
+                    card.classList.add("received-message-card");
+                }
+                card.innerHTML = newMessage.body + '</p><span class="duid">FROM DUCKID: '
+                 + newMessage.sduid + '</span></p><span class="time">' 
+                 + newMessage.messageAge + ' seconds ago</span>';
+
+                document.getElementById('message-container').prepend(card);
+            }
+            function chatHistoryListener () {
+                var data = JSON.parse(this.responseText);
+                data.posts.forEach(item => {
+                        let sent = sduid == item.sduid ? true : false;
+                        displayNewMessage(item, sent);
+                    });
+                
+            }
+            function sduidListener () {
+                sduid = JSON.parse(this.responseText);
+            }
+
+            function requestChatHistory(){
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", chatHistoryListener);
+                req.open("GET", "/chatHistory");
+                req.send();
+            }
+
+            function requestSduid(){
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", sduidListener);
+                req.open("GET", "/id");
+                req.send();
+            }
+
+
+
+            function loadListener(){
+                console.log('request returned');
+                var errEl = document.getElementById('makeshiftErrorOutput');
+                if (!errEl.classList.toString().includes("hidden")) {
+                    errEl.innerHTML = '';
+                    errEl.classList.add("hidden");
+                }
+            };
+            function errorListener(){
+                var errorMessage = 'There was an error sending the message. Please try again.';
+                console.log(errorMessage);
+                var errEl = document.getElementById('makeshiftErrorOutput');
+                errEl.innerHTML = errorMessage;
+                errEl.classList.remove("hidden");
+            };
+            function sendMessage(){
+                let message = document.getElementById('chatMessage');
+                let params = new URLSearchParams("");
+                params.append(message.name, message.value);
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", loadListener);
+                req.addEventListener("error", errorListener);
+                req.open("POST", "/chatSubmit.json?" + params.toString());
+                req.send();
+                displayNewMessage({body: message.value, messageAge: 0, sduid: sduid}, true);
+            }
+            
+            if (!!window.EventSource) {
+                var source = new EventSource('/events');
+
+                source.addEventListener('open', function(e) {
+                    console.log("Events Connected");
+                    
+                }, false);
+
+                source.addEventListener('error', function(e) {
+                    if (e.target.readyState != EventSource.OPEN) {
+                    console.log("Events Disconnected");
+                    }
+                }, false);
+                source.addEventListener('refreshPage', function(data) {
+                    location.reload(); 
+                }, false);
+
+            }
+            document.getElementById('sendBtn').addEventListener('click', sendMessage);
+            
+            requestSduid();
+            requestChatHistory();
+        </script>
+    </body>
+</html>
+
+
+<style>
+    .received-message-card{
+        border-radius: 10px;
+        background-color: #F0EEF7;
+        padding: 0 3vw 1vh;
+        margin: 2vw;
+        overflow:auto;
+        width: 70%;
+        padding-top: 5px;
+    }
+    .sent-message-card{
+        border-radius: 10px;
+        background-color: #ffff004f;
+        padding: 0 3vw 1vh;
+        margin: 2vw;
+        overflow:auto;
+        width: 70%;
+        float: right;
+        padding-top: 5px;
+    }
+    #message-container{
+        width: 95%;
+        margin: 10vh auto;
+    }
+    .time{
+        margin-right: 3vw;
+        float: right;
+        color: gray;
+        font-size: 0.8em;
+    }
+    .duid{
+        margin-left: 3vw;
+        float: left;
+        color: gray;
+        font-size: 0.8em;
+    }
+    #title{
+        font-size: 1.2em;
+        top: 20%;
+        position: relative;
+        font-weight: bold;
+    }
+    .title-bar{
+        background-color: black;
+        box-shadow: 0 2px 3px gray;
+        height: 35px;
+        position: fixed;
+        top: 0%;
+        width: 100%;
+        color: white;
+        left: 0%;
+        text-align: center;
+    }
+    .chat-bar{
+        background-color: #9b9389;
+        height: 35px;
+        position: fixed;
+        bottom: 0;
+        width: 100%;
+        padding: 5px;
+        left: 0%;
+    }
+    #chatMessage{
+        width: 70%;
+    }
+    #sendBtn{
+        background-color: #ffe700;
+        border-radius: 5px;
+        border-style: none;
+        height: 34px;
+        width: 100px;
+        float: right;
+        margin-right: 15px;
+    }
+    body{
+        font-family: sans-serif;
+        font-size: .9em;
+    }
+
+</style>
+)=====";
+#endif

--- a/src/include/privateChat.h
+++ b/src/include/privateChat.h
@@ -9,7 +9,7 @@ const char private_chat_page[] PROGMEM = R"=====(
     </head>
 
     <body>
-        <nav class="title-bar"><span id="title">PRIVATE CHAT</span></nav>
+        <nav class="title-bar"><span id="title">PRIVATE CHAT:</span></nav>
         <div id="chat-display">
             <div id="message-container"></div>
             <div class="chat-bar">
@@ -37,7 +37,7 @@ const char private_chat_page[] PROGMEM = R"=====(
                  + newMessage.sduid + '</span></p><span class="time">' 
                  + newMessage.messageAge + ' seconds ago</span>';
 
-                document.getElementById('message-container').prepend(card);
+                document.getElementById('message-container').append(card);
             }
             function chatHistoryListener () {
                 console.log(this.responseText);
@@ -46,14 +46,14 @@ const char private_chat_page[] PROGMEM = R"=====(
                         let sent = sduid == item.sduid ? true : false;
                         displayNewMessage(item, sent);
                     });
+                //document.getElementById('dduid').innerHtml = "PRIVATE CHAT: " + ;
                 
             }
             function sduidListener () {
-                sduid = JSON.parse(this.responseText);
+                sduid = this.responseText;
             }
 
             function requestChatHistory(){
-                //set dduid here?
                 var req = new XMLHttpRequest();
                 req.addEventListener("load", chatHistoryListener);
                 req.addEventListener("error", errorListener);
@@ -72,7 +72,6 @@ const char private_chat_page[] PROGMEM = R"=====(
 
 
             function loadListener(){
-                console.log('request returned');
                 var errEl = document.getElementById('makeshiftErrorOutput');
                 if (!errEl.classList.toString().includes("hidden")) {
                     errEl.innerHTML = '';
@@ -96,6 +95,8 @@ const char private_chat_page[] PROGMEM = R"=====(
                 req.open("POST", "/privateChatSubmit.json?" + params.toString());
                 req.send();
                 displayNewMessage({body: message.value, messageAge: 0, sduid: sduid}, true);
+
+                message.value = "";
             }
             
             if (!!window.EventSource) {
@@ -103,12 +104,10 @@ const char private_chat_page[] PROGMEM = R"=====(
 
                 source.addEventListener('open', function(e) {
                     console.log("Events Connected");
-                    
                 }, false);
 
                 source.addEventListener('error', function(e) {
                     if (e.target.readyState != EventSource.OPEN) {
-                    console.log("Events Disconnected");
                     }
                 }, false);
                 source.addEventListener('refreshPage', function(data) {

--- a/src/include/privateChat.h
+++ b/src/include/privateChat.h
@@ -40,6 +40,7 @@ const char private_chat_page[] PROGMEM = R"=====(
                 document.getElementById('message-container').prepend(card);
             }
             function chatHistoryListener () {
+                console.log(this.responseText);
                 var data = JSON.parse(this.responseText);
                 data.posts.forEach(item => {
                         let sent = sduid == item.sduid ? true : false;
@@ -52,15 +53,18 @@ const char private_chat_page[] PROGMEM = R"=====(
             }
 
             function requestChatHistory(){
+                //set dduid here?
                 var req = new XMLHttpRequest();
                 req.addEventListener("load", chatHistoryListener);
-                req.open("GET", "/chatHistory");
+                req.addEventListener("error", errorListener);
+                req.open("GET", "/privateChatHistory");
                 req.send();
             }
 
             function requestSduid(){
                 var req = new XMLHttpRequest();
                 req.addEventListener("load", sduidListener);
+                req.addEventListener("error", errorListener);
                 req.open("GET", "/id");
                 req.send();
             }
@@ -89,7 +93,7 @@ const char private_chat_page[] PROGMEM = R"=====(
                 var req = new XMLHttpRequest();
                 req.addEventListener("load", loadListener);
                 req.addEventListener("error", errorListener);
-                req.open("POST", "/chatSubmit.json?" + params.toString());
+                req.open("POST", "/privateChatSubmit.json?" + params.toString());
                 req.send();
                 displayNewMessage({body: message.value, messageAge: 0, sduid: sduid}, true);
             }

--- a/src/include/privateChat.h
+++ b/src/include/privateChat.h
@@ -40,7 +40,6 @@ const char private_chat_page[] PROGMEM = R"=====(
                 document.getElementById('message-container').append(card);
             }
             function chatHistoryListener () {
-                console.log(this.responseText);
                 var data = JSON.parse(this.responseText);
                 data.posts.forEach(item => {
                         let sent = sduid == item.sduid ? true : false;

--- a/src/include/privateChatPrompt.h
+++ b/src/include/privateChatPrompt.h
@@ -60,7 +60,6 @@ const char private_chat_prompt[] PROGMEM = R"=====(
                 button.onclick = ()=>openChatHistory(btnName);
             }
             function historiesListener () {
-                console.log(this.responseText);
                 var data = JSON.parse(this.responseText);
                 data.histories.forEach(item => {
                         createHistoryButton(item);

--- a/src/include/privateChatPrompt.h
+++ b/src/include/privateChatPrompt.h
@@ -13,10 +13,13 @@ const char private_chat_prompt[] PROGMEM = R"=====(
         <div id="form">
             <form>
                 <label for="dduid">Which device do you want to start a chat with?</label><br>
-                <textarea pattern="[A-NPZ1-9]{8}" maxlength=8 class="textbox textbox-full" name="dduid" placeholder="MAMA0001" cols="30" rows="2"></textarea>
+                <textarea pattern="[A-NPZ1-9]{8}" maxlength=8 class="textbox textbox-full" id="dduid" name="dduid" placeholder="MAMA0001" cols="30" rows="2"></textarea>
                 <button type="button" id="sendBtn">Start Chat</button>
                 <p id="makeshiftErrorOutput" class="hidden"></p>
             </form>
+        </div>
+        <h3>Chat Histories</h3>
+        <div id="histories">
         </div>
 
         <script>
@@ -25,18 +28,13 @@ const char private_chat_prompt[] PROGMEM = R"=====(
                 let params = new URLSearchParams("");
                 params.append(dduidInput.name, dduidInput.value);
                 let req = new XMLHttpRequest();
-                req.addEventListener("load", loadListener);
+                req.addEventListener("load", openChatListener);
                 req.addEventListener("error", errorListener);
-                req.open("POST", "/newPrivateChat.json?" + params.toString());
+                req.open("POST", "/openPrivateChat.json?" + params.toString());
                 req.send();
             }
-
-            function loadListener(){
-                let errEl = document.getElementById('makeshiftErrorOutput');
-                if (!errEl.classList.toString().includes("hidden")) {
-                    errEl.innerHTML = '';
-                    errEl.classList.add("hidden");
-                }
+            function openChatListener(){
+                window.location.replace("/private-chat");
             };
             function errorListener(){
                 let errorMessage = 'There was an error sending the message. Please try again.';
@@ -45,6 +43,39 @@ const char private_chat_prompt[] PROGMEM = R"=====(
                 errEl.innerHTML = errorMessage;
                 errEl.classList.remove("hidden");
             };
+            function openChatHistory(dduid){
+                let params = new URLSearchParams("");
+                params.append("dduid", dduid);
+                let req = new XMLHttpRequest();
+                req.addEventListener("load", openChatListener);
+                req.addEventListener("error", errorListener);
+                req.open("POST", "/openPrivateChat.json?" + params.toString());
+                req.send();
+                console.log('chat history opened');
+            };
+            function createHistoryButton(btnName){
+                var button = document.createElement("button");
+                button.classList.add("historyBtn");
+                button.innerHTML = btnName;
+                document.getElementById('histories').prepend(button);
+                button.onclick = ()=>openChatHistory(btnName);
+            }
+            function historiesListener () {
+                console.log(JSON.parse(this.responseText));
+                var data = JSON.parse(this.responseText);
+                console.log(this.responseText);
+                data.histories.forEach(item => {
+                        createHistoryButton(item);
+                    });
+            }
+            function retrieveHistories(){
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", historiesListener);
+                req.open("GET", "/privateChatHistories");
+                req.send();
+            }
+            retrieveHistories();
+            document.getElementById('sendBtn').addEventListener('click', submit);
         </script>
     </body>
 </html>
@@ -83,11 +114,21 @@ const char private_chat_prompt[] PROGMEM = R"=====(
         margin-top: 10px;
     }
     #sendBtn:hover {
-        background-color:#ccc;;
+        background-color:#ccc;
     }
     #sendBtn:active {
         position:relative;
         top:1px;
+    }
+    .historyBtn {
+        background-color: #ffe421;
+        max-width: 250px;
+        margin: auto;
+        padding: 18px 24px 14px;
+        border-radius: 3px;
+    }
+    #histories{
+
     }
     #title{
         font-size: 1.2em;

--- a/src/include/privateChatPrompt.h
+++ b/src/include/privateChatPrompt.h
@@ -1,0 +1,115 @@
+#ifndef PRIVATE_CHAT_PROMPT_H
+#define PRIVATE_CHAT_PROMPT_H
+const char private_chat_prompt[] PROGMEM = R"=====(
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>New Private Chat</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+
+    <body>
+        <nav class="title-bar"><span id="title">NEW PRIVATE CHAT</span></nav>
+        <div id="form">
+            <form>
+                <label for="dduid">Which device do you want to start a chat with?</label><br>
+                <textarea pattern="[A-NPZ1-9]{8}" maxlength=8 class="textbox textbox-full" name="dduid" placeholder="MAMA0001" cols="30" rows="2"></textarea>
+                <button type="button" id="sendBtn">Start Chat</button>
+                <p id="makeshiftErrorOutput" class="hidden"></p>
+            </form>
+        </div>
+
+        <script>
+            function submit(){
+                let dduidInput = document.getElementById('dduid');
+                let params = new URLSearchParams("");
+                params.append(dduidInput.name, dduidInput.value);
+                let req = new XMLHttpRequest();
+                req.addEventListener("load", loadListener);
+                req.addEventListener("error", errorListener);
+                req.open("POST", "/newPrivateChat.json?" + params.toString());
+                req.send();
+            }
+
+            function loadListener(){
+                let errEl = document.getElementById('makeshiftErrorOutput');
+                if (!errEl.classList.toString().includes("hidden")) {
+                    errEl.innerHTML = '';
+                    errEl.classList.add("hidden");
+                }
+            };
+            function errorListener(){
+                let errorMessage = 'There was an error sending the message. Please try again.';
+                console.log(errorMessage);
+                let errEl = document.getElementById('makeshiftErrorOutput');
+                errEl.innerHTML = errorMessage;
+                errEl.classList.remove("hidden");
+            };
+        </script>
+    </body>
+</html>
+
+
+<style>
+    #form{
+        background-color: #ffe421;
+        max-width: 250px;
+        margin: auto;
+        padding: 18px 24px 14px;
+        border-radius: 3px;
+        text-align: left;
+        margin-top: 60px;
+    }
+    .textbox {
+        border-radius: 4px;
+        border: none;
+        margin: .5em 0;
+    }
+    .textbox-full {
+        width: 100%;
+        height: 5em;
+    }
+    #sendBtn {
+        background-color: #f4f4ed;
+        border-radius: 5px;
+        border: none;
+        cursor: pointer;
+        color: #333333;
+        font-size: 15px;
+        font-weight: bold;
+        padding: 8px;
+        text-align: center;
+        width: 100%;
+        margin-top: 10px;
+    }
+    #sendBtn:hover {
+        background-color:#ccc;;
+    }
+    #sendBtn:active {
+        position:relative;
+        top:1px;
+    }
+    #title{
+        font-size: 1.2em;
+        top: 20%;
+        position: relative;
+        font-weight: bold;
+    }
+    .title-bar{
+        background-color: black;
+        box-shadow: 0 2px 3px gray;
+        height: 35px;
+        position: fixed;
+        top: 0%;
+        width: 100%;
+        color: white;
+        left: 0%;
+        text-align: center;
+    }
+    body{
+        font-family: sans-serif;
+        font-size: .9em;
+    }
+</style>
+)=====";
+#endif

--- a/src/include/privateChatPrompt.h
+++ b/src/include/privateChatPrompt.h
@@ -37,7 +37,7 @@ const char private_chat_prompt[] PROGMEM = R"=====(
                 window.location.replace("/private-chat");
             };
             function errorListener(){
-                let errorMessage = 'There was an error sending the message. Please try again.';
+                let errorMessage = 'There was an error starting the chat. Please try again.';
                 console.log(errorMessage);
                 let errEl = document.getElementById('makeshiftErrorOutput');
                 errEl.innerHTML = errorMessage;
@@ -74,6 +74,7 @@ const char private_chat_prompt[] PROGMEM = R"=====(
             }
             retrieveHistories();
             document.getElementById('sendBtn').addEventListener('click', submit);
+            document.getElementById("dduid").focus();
         </script>
     </body>
 </html>

--- a/src/include/privateChatPrompt.h
+++ b/src/include/privateChatPrompt.h
@@ -51,7 +51,6 @@ const char private_chat_prompt[] PROGMEM = R"=====(
                 req.addEventListener("error", errorListener);
                 req.open("POST", "/openPrivateChat.json?" + params.toString());
                 req.send();
-                console.log('chat history opened');
             };
             function createHistoryButton(btnName){
                 var button = document.createElement("button");
@@ -61,9 +60,8 @@ const char private_chat_prompt[] PROGMEM = R"=====(
                 button.onclick = ()=>openChatHistory(btnName);
             }
             function historiesListener () {
-                console.log(JSON.parse(this.responseText));
-                var data = JSON.parse(this.responseText);
                 console.log(this.responseText);
+                var data = JSON.parse(this.responseText);
                 data.histories.forEach(item => {
                         createHistoryButton(item);
                     });


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
src: Added a private and global chat feature between ducks, available through the cdp home page. Currently, up to 3 private chat histories are held on a duck.

**Is this a patch, a minor version change, or a major version change**
new feature

**To Do**
- make chat bar more responsive
- fix validation for dduid on chat prompt page
- display the dduid on the private chat header bar
- submit chat message when pushing enter (vs only the send button)
- add automatic scrolling to bottom of chat
- fix chat bar overlapping the latest message
- fix message age display: time is wrong on only your own (not the other device's) messages after page refresh
