### PR TITLE
src: replace message age in chats with username

### DIFF
--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -125,7 +125,7 @@ std::string DuckNet::retrieveMessageHistory(CircularBuffer* buffer)
     std::string messageBody(packet.data.begin(),packet.data.end());
     std::string sduid(packet.sduid.begin(), packet.sduid.end());
 
-    json = json + "{\"sduid\":\"" + sduid  + "\" , \"title\":\"PLACEHOLDER TITLE\", \"body\":\"" + messageBody + "\", \"messageAge\":\"" + messageAgeString + "\"}";
+    json = json + "{\"sduid\":\"" + sduid  + "\" , \"title\":\"PLACEHOLDER TITLE\", \"message\":" + messageBody + ", \"messageAge\":\"" + messageAgeString + "\"}";
 
     tail++;
     if(tail == buffer->getBufferEnd()){
@@ -163,6 +163,9 @@ int DuckNet::setupWebServer(bool createCaptivePortal, String html) {
 
   webServer.on("/message-board", HTTP_GET, [&](AsyncWebServerRequest* request) {
     request->send(200, "text/html", message_board);
+  });
+  webServer.on("/join-chat", HTTP_GET, [&](AsyncWebServerRequest* request) {
+    request->send(200, "text/html", chat_prompt);
   });
   webServer.on("/chat", HTTP_GET, [&](AsyncWebServerRequest* request) {
     request->send(200, "text/html", chat_page);

--- a/src/include/DuckNet.h
+++ b/src/include/DuckNet.h
@@ -47,6 +47,7 @@ class DuckNet;
 #include "papaHome.h"
 #include "messageBoard.h"
 #include "chatPage.h"
+#include "chatPrompt.h"
 #include "privateChat.h"
 #include "privateChatPrompt.h"
 #include "circularBuffer.h"

--- a/src/include/cdpHome.h
+++ b/src/include/cdpHome.h
@@ -16,7 +16,7 @@ const char home_page[] PROGMEM = R"=====(
 		<a href="/controlpanel">Control Panel</a>
 		<a href="/main">Send Message</a>
 		<a href="/message-board">Message Board</a>
-		<a href="/chat">Global Chat</a>
+		<a href="/join-chat">Global Chat</a>
 		<a href="/new-private-chat">Start a Private Chat</a>
 	</div>
   </body>

--- a/src/include/chatPage.h
+++ b/src/include/chatPage.h
@@ -96,7 +96,7 @@ const char chat_page[] PROGMEM = R"=====(
                 req.send();
                 displayNewMessage({message: { body: messageBody, username: username} , sduid: sduid}, true);
 
-                messageBody = "";
+                document.getElementById('chatMessage').value = "";
             }
             
             if (!!window.EventSource) {

--- a/src/include/chatPage.h
+++ b/src/include/chatPage.h
@@ -24,17 +24,18 @@ const char chat_page[] PROGMEM = R"=====(
 
         <script>
             var sduid = "you";
+            const username = sessionStorage.getItem("username");
+
              function displayNewMessage(newMessage, sent){
-                newMessage.messageAge = parseInt(newMessage.messageAge / 1000);
                 var card = document.createElement("div");
                 if(sent){
                     card.classList.add("sent-message-card");
                 }else{
                     card.classList.add("received-message-card");
                 }
-                card.innerHTML = newMessage.body + '</p><span class="duid">FROM DUCKID: '
-                 + newMessage.sduid + '</span></p><span class="time">' 
-                 + newMessage.messageAge + ' seconds ago</span>';
+                card.innerHTML = newMessage.message.body + '</p><span class="duid">FROM DUCKID: '
+                 + newMessage.sduid + '</span></p><span class="name">' 
+                 + newMessage.message.username + '</span>';
 
                 document.getElementById('message-container').prepend(card);
             }
@@ -81,17 +82,21 @@ const char chat_page[] PROGMEM = R"=====(
                 errEl.classList.remove("hidden");
             };
             function sendMessage(){
-                let message = document.getElementById('chatMessage');
-                let params = new URLSearchParams("");
-                params.append(message.name, message.value);
+                let messageBody = document.getElementById('chatMessage').value;
+                let message = JSON.stringify({
+                    body: messageBody,
+                    username: username
+                });
+                let messageParams = new URLSearchParams("");
+                messageParams.append("chatMessage", message);
                 var req = new XMLHttpRequest();
                 req.addEventListener("load", loadListener);
                 req.addEventListener("error", errorListener);
-                req.open("POST", "/chatSubmit.json?" + params.toString());
+                req.open("POST", "/chatSubmit.json?" + messageParams.toString());
                 req.send();
-                displayNewMessage({body: message.value, messageAge: 0, sduid: sduid}, true);
+                displayNewMessage({message: { body: messageBody, username: username} , sduid: sduid}, true);
 
-                message.value = "";
+                messageBody = "";
             }
             
             if (!!window.EventSource) {
@@ -144,7 +149,7 @@ const char chat_page[] PROGMEM = R"=====(
         width: 95%;
         margin: 10vh auto;
     }
-    .time{
+    .name{
         margin-right: 3vw;
         float: right;
         color: gray;

--- a/src/include/chatPrompt.h
+++ b/src/include/chatPrompt.h
@@ -1,0 +1,99 @@
+#ifndef CHAT_PROMPT_H
+#define CHAT_PROMPT_H
+const char chat_prompt[] PROGMEM = R"=====(
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>Join Public Chat</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+
+    <body>
+        <nav class="title-bar"><span id="title">JOIN PUBLIC CHAT</span></nav>
+        <div id="form">
+            <form>
+                <label for="username">Username: </label><br>
+                <textarea pattern="[A-NPZ1-9]{15}" maxlength=15 class="textbox textbox-full" id="username" name="username" placeholder="John" cols="30" rows="2" required></textarea>
+                <button type="button" id="sendBtn">Start Chat</button>
+                <p id="makeshiftErrorOutput" class="hidden"></p>
+            </form>
+        </div>
+
+        <script>
+            if(sessionStorage.getItem("username")){
+                document.getElementById("username").value = sessionStorage.getItem("username");
+            }
+            function submit(){
+                sessionStorage.setItem("username", document.getElementById('username').value);
+                window.location.replace("/chat");
+            }
+            document.getElementById('sendBtn').addEventListener('click', submit);
+            document.getElementById("username").focus();
+        </script>
+    </body>
+</html>
+
+
+<style>
+    #form{
+        background-color: #ffe421;
+        max-width: 250px;
+        margin: auto;
+        padding: 18px 24px 14px;
+        border-radius: 3px;
+        text-align: left;
+        margin-top: 60px;
+    }
+    .textbox {
+        border-radius: 4px;
+        border: none;
+        margin: .5em 0;
+    }
+    .textbox-full {
+        width: 100%;
+        height: 5em;
+    }
+    #sendBtn {
+        background-color: #f4f4ed;
+        border-radius: 5px;
+        border: none;
+        cursor: pointer;
+        color: #333333;
+        font-size: 15px;
+        font-weight: bold;
+        padding: 8px;
+        text-align: center;
+        width: 100%;
+        margin-top: 10px;
+    }
+    #sendBtn:hover {
+        background-color:#ccc;
+    }
+    #sendBtn:active {
+        position:relative;
+        top:1px;
+    }
+    #title{
+        font-size: 1.2em;
+        top: 20%;
+        position: relative;
+        font-weight: bold;
+    }
+    .title-bar{
+        background-color: black;
+        box-shadow: 0 2px 3px gray;
+        height: 35px;
+        position: fixed;
+        top: 0%;
+        width: 100%;
+        color: white;
+        left: 0%;
+        text-align: center;
+    }
+    body{
+        font-family: sans-serif;
+        font-size: .9em;
+    }
+</style>
+)=====";
+#endif

--- a/src/include/privateChat.h
+++ b/src/include/privateChat.h
@@ -25,17 +25,18 @@ const char private_chat_page[] PROGMEM = R"=====(
 
         <script>
             var sduid = "you";
+            const username = sessionStorage.getItem("username");
+
              function displayNewMessage(newMessage, sent){
-                newMessage.messageAge = parseInt(newMessage.messageAge / 1000);
                 var card = document.createElement("div");
                 if(sent){
                     card.classList.add("sent-message-card");
                 }else{
                     card.classList.add("received-message-card");
                 }
-                card.innerHTML = newMessage.body + '</p><span class="duid">FROM DUCKID: '
-                 + newMessage.sduid + '</span></p><span class="time">' 
-                 + newMessage.messageAge + ' seconds ago</span>';
+                card.innerHTML = newMessage.message.body + '</p><span class="duid">FROM DUCKID: '
+                 + newMessage.sduid + '</span></p><span class="name">' 
+                 + newMessage.message.username + '</span>';
 
                 document.getElementById('message-container').append(card);
             }
@@ -48,8 +49,16 @@ const char private_chat_page[] PROGMEM = R"=====(
                 //document.getElementById('dduid').innerHtml = "PRIVATE CHAT: " + ;
                 
             }
-            function sduidListener () {
+
+            function sduidListener(){
                 sduid = this.responseText;
+            }
+            function requestSduid(){
+                var req = new XMLHttpRequest();
+                req.addEventListener("load", sduidListener);
+                req.addEventListener("error", errorListener);
+                req.open("GET", "/id");
+                req.send();
             }
 
             function requestChatHistory(){
@@ -59,15 +68,6 @@ const char private_chat_page[] PROGMEM = R"=====(
                 req.open("GET", "/privateChatHistory");
                 req.send();
             }
-
-            function requestSduid(){
-                var req = new XMLHttpRequest();
-                req.addEventListener("load", sduidListener);
-                req.addEventListener("error", errorListener);
-                req.open("GET", "/id");
-                req.send();
-            }
-
 
 
             function loadListener(){
@@ -85,17 +85,21 @@ const char private_chat_page[] PROGMEM = R"=====(
                 errEl.classList.remove("hidden");
             };
             function sendMessage(){
-                let message = document.getElementById('chatMessage');
-                let params = new URLSearchParams("");
-                params.append(message.name, message.value);
+                let messageBody = document.getElementById('chatMessage').value;
+                let message = JSON.stringify({
+                    body: messageBody,
+                    username: username
+                });
+                let messageParams = new URLSearchParams("");
+                messageParams.append("chatMessage", message);
                 var req = new XMLHttpRequest();
                 req.addEventListener("load", loadListener);
                 req.addEventListener("error", errorListener);
-                req.open("POST", "/privateChatSubmit.json?" + params.toString());
+                req.open("POST", "/privateChatSubmit.json?" + messageParams.toString());
                 req.send();
-                displayNewMessage({body: message.value, messageAge: 0, sduid: sduid}, true);
+                displayNewMessage({message: { body: messageBody, username: username} , sduid: sduid}, true);
 
-                message.value = "";
+                messageBody = "";
             }
             
             if (!!window.EventSource) {
@@ -146,7 +150,7 @@ const char private_chat_page[] PROGMEM = R"=====(
         width: 95%;
         margin: 10vh auto;
     }
-    .time{
+    .name{
         margin-right: 3vw;
         float: right;
         color: gray;

--- a/src/include/privateChat.h
+++ b/src/include/privateChat.h
@@ -99,7 +99,7 @@ const char private_chat_page[] PROGMEM = R"=====(
                 req.send();
                 displayNewMessage({message: { body: messageBody, username: username} , sduid: sduid}, true);
 
-                messageBody = "";
+                document.getElementById('chatMessage').value = "";
             }
             
             if (!!window.EventSource) {

--- a/src/include/privateChatPrompt.h
+++ b/src/include/privateChatPrompt.h
@@ -13,7 +13,9 @@ const char private_chat_prompt[] PROGMEM = R"=====(
         <div id="form">
             <form>
                 <label for="dduid">Which device do you want to start a chat with?</label><br>
-                <textarea pattern="[A-NPZ1-9]{8}" maxlength=8 class="textbox textbox-full" id="dduid" name="dduid" placeholder="MAMA0001" cols="30" rows="2"></textarea>
+                <textarea pattern="[A-NPZ1-9]{8}" maxlength=8 class="textbox textbox-full" id="dduid" name="dduid" placeholder="MAMA0001" cols="30" rows="2" required></textarea>
+                <label for="username">Username: </label><br>
+                <textarea pattern="[A-NPZ1-9]{15}" maxlength=15 class="textbox textbox-full" id="username" name="username" placeholder="John" cols="30" rows="2" required></textarea>
                 <button type="button" id="sendBtn">Start Chat</button>
                 <p id="makeshiftErrorOutput" class="hidden"></p>
             </form>
@@ -23,8 +25,14 @@ const char private_chat_prompt[] PROGMEM = R"=====(
         </div>
 
         <script>
+            if(sessionStorage.getItem("username")){
+                document.getElementById("username").value = sessionStorage.getItem("username");
+            }
+
+        //actually save the name in the chatbuffer
             function submit(){
                 let dduidInput = document.getElementById('dduid');
+                sessionStorage.setItem("username", document.getElementById('username').value);
                 let params = new URLSearchParams("");
                 params.append(dduidInput.name, dduidInput.value);
                 let req = new XMLHttpRequest();


### PR DESCRIPTION
Replaces the message age in global and private chat with a username stored in the client's `sessionStorage`, which is cleared on closing of the tab/window. Adds a prompt before global chat for entering a username.

Known issues: 
- Opening an existing private chat history when the username has 
not been set in this tab sets the username to null
- Chat prompt inputs are not being enforced as `required`

**Is this a patch, a minor version change, or a major version change**
patch
