### PR TITLE
Chat disappearance fix, filter out pchat from DMS

### DIFF
--- a/examples/1.Ducks/PapaDuck/PapaDuck.ino
+++ b/examples/1.Ducks/PapaDuck/PapaDuck.ino
@@ -214,14 +214,17 @@ int quackJson(CdpPacket packet) {
   String jsonstat;
   serializeJson(doc, jsonstat);
 
-  if (client.publish(topic.c_str(), jsonstat.c_str())) {
-    Serial.println("[PAPA] Packet forwarded:");
-    serializeJsonPretty(doc, Serial);
-    Serial.println("");
-    Serial.println("[PAPA] Publish ok");
-    display->drawString(0, 60, "Publish ok");
-    display->sendBuffer();
-    return 0;
+ //Filter out private chat so it won't get sent to DMS
+  if(cdpTopic == "pchat") {
+    return -1;
+  } else if(client.publish(topic.c_str(), jsonstat.c_str())) {
+      Serial.println("[PAPA] Packet forwarded:");
+      serializeJsonPretty(doc, Serial);
+      Serial.println("");
+      Serial.println("[PAPA] Publish ok");
+      display->drawString(0, 60, "Publish ok");
+      display->sendBuffer();
+      return 0;
   } else {
     Serial.println("[PAPA] Publish failed");
     display->drawString(0, 60, "Publish failed");

--- a/examples/5.Custom-Papa-Examples/Papa-DishDuck-WiFi/Papa-DishDuck-WiFi.ino
+++ b/examples/5.Custom-Papa-Examples/Papa-DishDuck-WiFi/Papa-DishDuck-WiFi.ino
@@ -245,7 +245,10 @@ void quackJson(std::vector<byte> packetBuffer) {
   String jsonstat;
   serializeJson(doc, jsonstat);
 
-  if (client.publish(topic.c_str(), jsonstat.c_str())) {
+  //Filter out private chat so it won't get sent to DMS
+  if(cdpTopic == "pchat") {
+    return -1;
+  } else if(client.publish(topic.c_str(), jsonstat.c_str())) {
     Serial.println("[DISH] Packet forwarded:");
     serializeJsonPretty(doc, Serial);
     Serial.println("");

--- a/examples/5.Custom-Papa-Examples/Papa-Downtime-Counter/Papa-Downtime-Counter.ino
+++ b/examples/5.Custom-Papa-Examples/Papa-Downtime-Counter/Papa-Downtime-Counter.ino
@@ -174,8 +174,11 @@ int quackJson(std::vector<byte> packetBuffer) {
 
   String jsonstat;
   serializeJson(doc, jsonstat);
-
-  if (client.publish(topic.c_str(), jsonstat.c_str())) {
+  
+//Filter out private chat so it won't get sent to DMS
+  if(cdpTopic == "pchat") {
+    return -1;
+  } else if(client.publish(topic.c_str(), jsonstat.c_str())) {
     Serial.println("[PAPA] Packet forwarded:");
     serializeJsonPretty(doc, Serial);
     Serial.println("");
@@ -324,7 +327,10 @@ void quackDownReport(String payload) {
   String jsonstat;
   serializeJson(doc, jsonstat);
 
-  if (client.publish(topic.c_str(), jsonstat.c_str())) {
+  //Filter out private chat so it won't get sent to DMS
+  if(cdpTopic == "pchat") {
+    return -1;
+  } else if(client.publish(topic.c_str(), jsonstat.c_str())) {
     Serial.println("[PAPA] Packet forwarded:");
     serializeJsonPretty(doc, Serial);
     Serial.println("");

--- a/examples/7.Encryption/DecryptionPapaDuck/DecryptionPapaDuck.ino
+++ b/examples/7.Encryption/DecryptionPapaDuck/DecryptionPapaDuck.ino
@@ -157,7 +157,10 @@ int quackJson(std::vector<byte> packetBuffer) {
    String jsonstat;
    serializeJson(doc, jsonstat);
 
-   if (client.publish(topic.c_str(), jsonstat.c_str())) {
+   //Filter out private chat so it won't get sent to DMS
+  if(cdpTopic == "pchat") {
+    return -1;
+  } else if(client.publish(topic.c_str(), jsonstat.c_str())) {
       Serial.println("[PAPA] Packet forwarded:");
       serializeJsonPretty(doc, Serial);
       Serial.println("");

--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -11,8 +11,8 @@ DuckNet::DuckNet(Duck* duckIn):
 
 //when initializing the buffer, the buffer created will be one larger than the provided size
 //one slot in the buffer is used as a waste slot
-CircularBuffer messageBuffer = CircularBuffer(5);
-CircularBuffer chatBuffer = CircularBuffer(20);
+CircularBuffer messageBuffer = CircularBuffer(CDPCFG_CDP_CHATBUF_SIZE);
+CircularBuffer chatBuffer = CircularBuffer(CDPCFG_CDP_CHATBUF_SIZE);
 std::map<std::string, CircularBuffer*> chatHistories;
 std::string duckSession = duckutils::toString(BROADCAST_DUID).c_str();
 
@@ -98,7 +98,7 @@ void DuckNet::addToPrivateChatBuffer(CdpPacket message, std::string chatSession)
 void DuckNet::createPrivateHistory(std::string session)
 {
   if(chatHistories.find(session) == chatHistories.end()){
-      CircularBuffer* privateChatBuffer = new CircularBuffer(20);
+      CircularBuffer* privateChatBuffer = new CircularBuffer(CDPCFG_CDP_CHATBUF_SIZE);
       if(chatHistories.size() >= 3){
         delete chatHistories.begin()->second;
         chatHistories.erase(chatHistories.begin());

--- a/src/DuckNet.cpp
+++ b/src/DuckNet.cpp
@@ -384,11 +384,9 @@ int DuckNet::setupWebServer(bool createCaptivePortal, String html) {
     message.insert(message.end(), msg.begin(), msg.end());
 
     std::vector<byte> muid;
-    std::vector<byte> session;
-    session.insert(session.end(), duckSession.begin(), duckSession.end());
 
-    err = duck->sendData(topics::gchat, message, session, &muid);
-    addToChatBuffer(duck->buildCdpPacket(topics::gchat, message, session, muid));
+    err = duck->sendData(topics::gchat, message, BROADCAST_DUID, &muid);
+    addToChatBuffer(duck->buildCdpPacket(topics::gchat, message, BROADCAST_DUID, muid));
 
     switch (err) {
       case DUCK_ERR_NONE:

--- a/src/include/cdpcfg.h
+++ b/src/include/cdpcfg.h
@@ -228,6 +228,9 @@
 /// CDP UUID generator max length
 #define CDPCFG_UUID_LEN 8
 
+/// CDP chat circular buffer size
+#define CDPCFG_CDP_CHATBUF_SIZE 15
+
 /// CDP ALIVE timer duration in milliseconds
 #define CDPCFG_MILLIS_ALIVE 1800000
 /// CDP REBOOT timer duration in milliseconds


### PR DESCRIPTION
Fixes bug where global chat disappears before visiting private chat, filters out pchat topic from being sent to DMS, and adds a config variable for chat buffer sizes.

**Is this a patch, a minor version change, or a major version change**
Patch

**Steps to test**

- Global Chat
    1. Deployed two ducks, 1 MamaDuck and 1 PapaDuck
    2. Connect to the MamaDuck
    3. Enter the captive portal
    4. Go to “Global Chat”
    5. Submit any message
    6. see that message pop up on the global chat
    7. Connect to the PapaDuck
    8. Enter the captive portal
    9. Go to “Global Chat”
    10. Confirm that the message sent from the MamaDuck is there

- Private Chat
    1. Connect to the MamaDuck
    2. Enter the captive portal
    3. Go to “Private Chat”
    4. Add the PapaDuck (the deviceID of PapaDuck, default is PAPAUCK) as the destination device
    5. Send a message
    6. Connect to the PapaDuck
    7. Enter the captive portal
    8. Go to “Private Chat”
    9. Confirm that the message is received on both Ducks
    10. Confirm that the message is not visible in the DMS









