### PR TITLE
added free memory data

### DIFF
--- a/examples/6.TTGO-TBeam-Examples/TBeam-Telemetry/TBeam-Telemetry.ino
+++ b/examples/6.TTGO-TBeam-Examples/TBeam-Telemetry/TBeam-Telemetry.ino
@@ -94,7 +94,7 @@ bool runSensor(void *) {
   const byte* buffer;
 
   // Creating the message to be sent 
-  String message = "Counter:" + String(counter)+ " " +getGPSData() + " " + getBatteryData();
+  String message = "Counter:" + String(counter)+ " " +String("Free Memory:") + String(freeMemory()) + " " + getGPSData() + " " + getBatteryData();
   Serial.print("[MAMA] sensor data: ");
   Serial.println(message);
   


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
I added a free heap memory into the telemetry data for the T-Beam.

**Is this a patch, a minor version change, or a major version change**
patch

**Is this related to an open issue?**
https://github.com/Call-for-Code/ClusterDuck-Protocol/issues/196

**Additional context**
To test this pull request, you will need a TBeam. Upload the example in Ducks-> TTGO-TBeam-Examples-> TBeam-Telemetry-Example and the free memory will be sent.