### PR TITLE
added amirs text limitation

### DIFF
--- a/src/include/index.h
+++ b/src/include/index.h
@@ -201,8 +201,21 @@ const char MAIN_page[] PROGMEM = R"=====(
             <p>ID must be four characters long. It can be any capital letters of the Latin alphabet A-Z except O, or any
                 numbers 1-9.</p>
             <label for="status">Your message:</label><br/>
-            <textarea class="textbox comments textbox-full" name="message" id="commentsInput" cols="30"
-                      rows="2"></textarea>
+            <textarea class="textbox comments textbox-full" maxlength=200 name="message" id="commentsInput" cols="30"
+                      rows="2" onkeyup="updateCounter(this)"></textarea>
+
+                    Remaining characters: <span id="counter">200</span>
+
+                    <script type="text/javascript">
+                    function updateCounter(textarea) {
+                        var currentLength = textarea.value.length;
+                        var maxCharacters = 200;
+                        var remainingCharacters = maxCharacters - currentLength;
+                        document.getElementById("counter").innerHTML = remainingCharacters;  
+                    }
+                    </script>
+            </textarea>
+                      
             <button type="button" id="sendBtn" class="sendReportBtn">Send</button>
             <p id="makeshiftErrorOutput" class="hidden"></p>
         </form>


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
There should be a character limit in the captive portal message to prevent anyone from breaking a CDP packet. Using Amir's code, it limits the message to 200 characters and shows how many characters left.

**Is this a patch, a minor version change, or a major version change**
patch

**Is this related to an open issue?**
https://github.com/Call-for-Code/ClusterDuck-Protocol/issues/307

**Testing Methodology. How can someone test your pull request?** 
Upload the firmware into a device and open the captive portal. Select "Send a Message" and type in a message. The limit should be 200 characters and there should be a prompt showing the number of remaining characters left. The message should send as normal. 

**Additional context**
Add any other technical detail or considerations here.
