### PR TITLE
update Papa example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This project is licensed under the Apache 2 License - see the [LICENSE](LICENSE)
 
 ## Version
 
-v3.5.1
+v3.6.1
 
 See `library.json` (PlatformIO) or `library.properties` (Arduino).
 

--- a/examples/1.Ducks/PapaDuck/PapaDuck.ino
+++ b/examples/1.Ducks/PapaDuck/PapaDuck.ino
@@ -1,16 +1,16 @@
 /**
  * @file PapaDuck.ino
- * @author 
+ * @author Timo Wielink
  * @brief Uses built-in PapaDuck from the SDK to create a WiFi enabled Papa Duck
- * 
+ *
  * This example will configure and run a Papa Duck that connects to the cloud
  * and forwards all messages (except  pings) to the cloud. When disconnected
  * it will add received packets to a queue. When it reconnects to MQTT it will
  * try to publish all messages in the queue. You can change the size of the queue
  * by changing `QUEUE_SIZE_MAX`.
- * 
- * @date 2021-11-18
- * 
+ *
+ * @date 09-07-2023
+ *
  */
 
 #include <ArduinoJson.h>
@@ -24,55 +24,28 @@
 #include <CdpPacket.h>
 #include <queue>
 
-//Uncomment CA_CERT if you want to use the certificate auth method
-//#define CA_CERT
-#ifdef CA_CERT
-const char* example_root_ca = \
-  "-----BEGIN CERTIFICATE-----\n" \
-  "MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh\n" \
-  "MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3\n" \
-  "d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD\n" \
-  "QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT\n" \
-  "MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j\n" \
-  "b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG\n" \
-  "9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB\n" \
-  "CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97\n" \
-  "nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt\n" \
-  "43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P\n" \
-  "T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4\n" \
-  "gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO\n" \
-  "BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR\n" \
-  "TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw\n" \
-  "DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr\n" \
-  "hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg\n" \
-  "06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF\n" \
-  "PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls\n" \
-  "YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk\n" \
-  "CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=\n" \
-  "-----END CERTIFICATE-----\n";
-  // This is the DigiCert Global Root CA, which is the root CA cert for
-  // https://internetofthings.ibmcloud.com/
-  // It expires November 9, 2031.
-  // To connect to a different cloud provider or server, you may need to use a
-  // different cert. For details, see
-  // https://github.com/espressif/arduino-esp32/tree/master/libraries/WiFiClientSecure
-#endif
- 
-#define SSID ""
-#define PASSWORD ""
+#include "secrets.h"
 
+#define CA_CERT
+#ifdef CA_CERT
+#endif
+
+#define SSID "" // Your WiFi SSID (Make sure its a 2.4 Ghz network)
+#define PASSWORD "" // Your WiFi Password
+
+// Leave these empty
 #define ORG         ""
 #define DEVICE_ID   ""
 #define DEVICE_TYPE ""
 #define TOKEN       ""
 
 
-char server[] = ORG ".messaging.internetofthings.ibmcloud.com";
+char server[] = ORG ""; // Your AWS IoT Core Endpoint
 char authMethod[] = "use-token-auth";
 char token[] = TOKEN;
-char clientId[] = "d:" ORG ":" DEVICE_TYPE ":" DEVICE_ID;
+char clientId[] = "TestPapa02";
 
-#define CMD_STATE_WIFI "/wifi/" 
+#define CMD_STATE_WIFI "/wifi/"
 #define CMD_STATE_HEALTH "/health/"
 #define CMD_STATE_CHANNEL "/channel/"
 #define CMD_STATE_MBM "/messageBoard/"
@@ -171,7 +144,7 @@ int quackJson(CdpPacket packet) {
   StaticJsonDocument<bufferSize> doc;
 
   // Here we treat the internal payload of the CDP packet as a string
-  // but this is mostly application dependent. 
+  // but this is mostly application dependent.
   // The parsingf here is optional. The Papa duck could simply decide to
   // forward the CDP packet as a byte array and let the Network Server (or DMS) deal with
   // the parsing based on some business logic.
@@ -208,13 +181,15 @@ int quackJson(CdpPacket packet) {
   display->drawString(0, 30, muid.c_str());
   display->drawString(0, 40, cdpTopic.c_str());
   display->sendBuffer();
-    
-  std::string topic = "iot-2/evt/" + cdpTopic + "/fmt/json";
+
+  //  std::string topic = "iot-2/evt/" + cdpTopic + "/fmt/json";
+  // std::string topic = "topic_2";
+  std::string topic = "owl/device/" + sduid + "/evt/" + cdpTopic;
 
   String jsonstat;
   serializeJson(doc, jsonstat);
 
- //Filter out private chat so it won't get sent to DMS
+  //Filter out private chat so it won't get sent to DMS
   if(cdpTopic == "pchat") {
     return -1;
   } else if(client.publish(topic.c_str(), jsonstat.c_str())) {
@@ -238,7 +213,7 @@ int quackJson(CdpPacket packet) {
 void handleDuckData(std::vector<byte> packetBuffer) {
   Serial.println("[PAPA] got packet: " +
                  convertToHex(packetBuffer.data(), packetBuffer.size()));
-  
+
   CdpPacket packet = CdpPacket(packetBuffer);
   if(packet.topic != reservedTopic::ack) {
     if(quackJson(packet) == -1) {
@@ -252,7 +227,7 @@ void handleDuckData(std::vector<byte> packetBuffer) {
       Serial.println(packetQueue.size());
     }
   }
-  
+
   subscribeTo(commandTopic);
 }
 
@@ -278,14 +253,17 @@ void setup() {
 
   #ifdef CA_CERT
   Serial.println("[PAPA] Using root CA cert");
-  wifiClient.setCACert(example_root_ca);
+  wifiClient.setCACert(AWS_CERT_CA);
+  wifiClient.setCertificate(AWS_CERT_CRT);
+  wifiClient.setPrivateKey(AWS_CERT_PRIVATE);
   #else
   Serial.println("[PAPA] Using insecure TLS");
   wifiClient.setInsecure();
   #endif
 
+
   Serial.println("[PAPA] Setup OK! ");
-  
+
    duck.enableAcks(true);
   // we are done
   display->showDefaultScreen();
@@ -299,7 +277,7 @@ void loop() {
 
       Serial.println("[PAPA] WiFi disconnected, reconnecting to local network: " +
                      ssid);
-
+                     
       int err = duck.reconnectWifi(ssid, password);
 
       if (err != DUCK_ERR_NONE) {
@@ -312,17 +290,17 @@ void loop() {
      if(duck.isWifiConnected()) {
         mqttConnect();
      }
-      
+
    }
-   
+
    duck.run();
    timer.tick();
- 
+
 }
 
 void gotMsg(char* topic, byte* payload, unsigned int payloadLength) {
   Serial.print("gotMsg: invoked for topic: "); Serial.println(topic);
- 
+
   if (String(topic).indexOf(CMD_STATE_WIFI) > 0) {
     Serial.println("Start WiFi Command");
     byte sCmd = 1;
@@ -330,13 +308,13 @@ void gotMsg(char* topic, byte* payload, unsigned int payloadLength) {
 
     if(payloadLength > 3) {
       std::string destination = "";
-      for (int i=1; i<payloadLength; i++) {
+      for (int i=0; i<payloadLength; i++) {
         destination += (char)payload[i];
       }
-      
+
       std::vector<byte> dDevId;
       dDevId.insert(dDevId.end(),destination.begin(),destination.end());
-      
+
       duck.sendCommand(sCmd, sValue, dDevId);
     } else {
       duck.sendCommand(sCmd, sValue);
@@ -349,12 +327,12 @@ void gotMsg(char* topic, byte* payload, unsigned int payloadLength) {
       for (int i=1; i<payloadLength; i++) {
         destination += (char)payload[i];
       }
-      
+
       std::vector<byte> dDevId;
       dDevId.insert(dDevId.end(),destination.begin(),destination.end());
-      
+
       duck.sendCommand(sCmd, sValue, dDevId);
-      
+
     } else {
       Serial.println("Payload size too small");
     }
@@ -364,12 +342,12 @@ void gotMsg(char* topic, byte* payload, unsigned int payloadLength) {
       for (int i = 0; i<payloadLength; i++) {
         output = output + (char)payload[i];
       }
-   
+
       message.insert(message.end(),output.begin(),output.end());
       duck.sendMessageBoardMessage(message);
   } else {
-    Serial.print("gotMsg: unexpected topic: "); Serial.println(topic); 
-  } 
+    Serial.print("gotMsg: unexpected topic: "); Serial.println(topic);
+  }
 }
 
 void wifiConnect() {
@@ -378,14 +356,14 @@ void wifiConnect() {
  while (WiFi.status() != WL_CONNECTED) {
    delay(500);
    Serial.print(".");
- } 
+ }
  Serial.print("\nWiFi connected, IP address: "); Serial.println(WiFi.localIP());
 }
 
 void mqttConnect() {
    if (!!!client.connected()) {
       Serial.print("Reconnecting MQTT client to "); Serial.println(server);
-      if(!!!client.connect(clientId, authMethod, token) && retry) {
+      if(!!!client.connect(clientId) && retry) {
          Serial.print("Connection failed, retry in 5 seconds");
          retry = false;
          timer.in(5000, enableRetry);

--- a/examples/1.Ducks/PapaDuck/secrets.h
+++ b/examples/1.Ducks/PapaDuck/secrets.h
@@ -1,0 +1,36 @@
+/*
+  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  Permission is hereby granted, free of charge, to any person obtaining a copy of this
+  software and associated documentation files (the "Software"), to deal in the Software
+  without restriction, including without limitation the rights to use, copy, modify,
+  merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+  permit persons to whom the Software is furnished to do so.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+  INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+  PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+  OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+  SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <pgmspace.h>
+
+#define SECRET
+#define THINGNAME "" // Your AWS IoT core Thing Name
+
+const char AWS_IOT_ENDPOINT[] = ""; // Your AWS IoT Core Endpoint
+
+// Amazon Root CA 1
+static const char AWS_CERT_CA[] PROGMEM = R"EOF(
+
+)EOF";
+
+// Device Certificate
+static const char AWS_CERT_CRT[] PROGMEM = R"KEY(
+
+)KEY";
+
+// Device Private Key
+static const char AWS_CERT_PRIVATE[] PROGMEM = R"KEY(
+
+)KEY";

--- a/library.json
+++ b/library.json
@@ -8,7 +8,7 @@
         "email": "info@project-owl.com",
         "url": "https://www.project-owl.com"
     },
-    "version": "3.5.1",
+    "version": "3.6.1",
     "repository":
     {
         "type": "git",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ClusterDuck Protocol
-version=3.5.1
+version=3.6.1
 author=OWL Integrations <info@owlintegrations.com>
 maintainer=OWL Integrations <info@owlintegrations.com>
 sentence=Mesh communication protocol.

--- a/src/DuckUtils.cpp
+++ b/src/DuckUtils.cpp
@@ -8,7 +8,7 @@
 namespace duckutils {
 
   namespace {
-    std::string cdpVersion = "3.5.1";
+    std::string cdpVersion = "3.6.1";
   }
 
 Timer<> duckTimer = timer_create_default();


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
I have converted the PapaDuck Example to work with AWS IoT core instead of the discontinued IBM Watson IoT Platform

**Is this a patch, a minor version change, or a major version change**
Minor

**Testing Methodology. How can someone test your pull request?** 
Follow the instructions created [here](https://github.com/Call-for-Code/ClusterDuck-Protocol/wiki/Setting-up-AWS-IoT-Core-endpoint)

Wiki has also been updated [here](https://github.com/Call-for-Code/ClusterDuck-Protocol/wiki/Setting-up-AWS-IoT-Core-endpoint)

