### PR TITLE
added freememory header

### DIFF
--- a/examples/1.Ducks/MamaDuck/MamaDuck.ino
+++ b/examples/1.Ducks/MamaDuck/MamaDuck.ino
@@ -6,6 +6,7 @@
 #include <string>
 #include <arduino-timer.h>
 #include <MamaDuck.h>
+#include <MemoryFree.h>
 
 #ifdef SERIAL_PORT_USBVIRTUAL
 #define Serial SERIAL_PORT_USBVIRTUAL
@@ -50,7 +51,7 @@ bool runSensor(void *) {
   bool result;
   const byte* buffer;
   
-  String message = String("Counter:") + String(counter);
+  String message = String("Counter:") + String(counter)+ " " +String("Free Memory:") + String(freeMemory());
   int length = message.length();
   Serial.print("[MAMA] sensor data: ");
   Serial.println(message);

--- a/examples/6.TTGO-TBeam-Examples/TBeam-Telemetry/TBeam-Telemetry.ino
+++ b/examples/6.TTGO-TBeam-Examples/TBeam-Telemetry/TBeam-Telemetry.ino
@@ -12,6 +12,7 @@
 #include <string>
 #include <arduino-timer.h>
 #include <MamaDuck.h>
+#include <MemoryFree.h>
 
 #ifdef SERIAL_PORT_USBVIRTUAL
 #define Serial SERIAL_PORT_USBVIRTUAL


### PR DESCRIPTION
**Describe at a high level the solution you're providing**
In order for `freeMemory()` to work the `MemoryFree.h` needed to be included. I added that header into the ino files.

**Is this a patch, a minor version change, or a major version change**
patch

**Is this related to an open issue?**
Please provide the link.

**Testing Methodology. How can someone test your pull request?** 
Test the `examples -> 1. Ducks -> MamaDuck -> MamaDuck.ino` and `examples -> 6.TTGO-TBeam-Examples -> TBeam-Telemetry` to see if it compiles and the Free memory is printing in the serial monitor

**Additional context**
Add any other technical detail or considerations here.
